### PR TITLE
bug(vscode): Remove autopep8 recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
     "recommendations": [
         "ms-python.mypy-type-checker",
-        "ms-python.autopep8",
         "ms-python.vscode-pylance",
         "ms-python.python",
         "ms-python.debugpy",


### PR DESCRIPTION
## Title

bug(vscode): Remove autopep8 recommendation

### Description

Removes recommendation to install `autopep8`, which is an incompatible code formatter to the one used by the repo (ruff).

### Related Issue(s)

Resolves #17 

### Reviewers

@nitzan-frock 

### Acceptance Criteria

Review.

### Testing

I opened VSCode and confirmed it did not recommend installing autopep8.
