### PR TITLE
fix(build): Fix `mypy` path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ lint: ## Run linting
 	@$(VENV_BIN)/pre-commit run;
 
 types: ## Run type checks
-	mypy
+	@$(VENV_BIN)/mypy;
 
 
 # Group: Database


### PR DESCRIPTION
## Title

fix(build): Fix `mypy` path in Makefile

### Description

Fixes path for `mypy` so it runs inside the virtual environment set up by `uv`.

### Related Issue(s)

Resolves #47 

### Reviewers

@nitzan-frock 
@swyatt7 
@crpellegrino 
@Kirill-Vorobyev 

### Acceptance Criteria

Testing and acceptance.

### Testing

Tested in fresh shell.
