### PR TITLE
feat(build): Alter `make lock` so it rebuilds lock files for all environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,12 @@ install_hooks: ## Install 'pre-commit' git hooks, only for local.
 
 lock: check_env venv ## Create or update the lockfile
 	@echo "Updating lockfile...";
-	@uv pip compile $(REQ_IN) -o $(REQ_TXT) --quiet;
+	@for env in $(ENVS); do \
+		in_file=$(REQ_DIR)/$$env.in; \
+		out_file=$(REQ_DIR)/$$env.txt; \
+		echo "Compiling $$in_file -> $$out_file"; \
+		uv pip compile $$in_file -o $$out_file --quiet; \
+	done
 
 configure: ## Create a .env file for environment variables
 	@echo "Creating .env file..."

--- a/requirements/action.txt
+++ b/requirements/action.txt
@@ -41,7 +41,7 @@ cfgv==3.4.0
     # via pre-commit
 click==8.1.7
     # via uvicorn
-coverage[toml]==7.6.9
+coverage==7.6.9
     # via pytest-cov
 distlib==0.3.9
     # via virtualenv
@@ -194,6 +194,7 @@ types-shapely==2.0.0.20241112
 typing-extensions==4.12.2
     # via
     #   alembic
+    #   anyio
     #   fastapi
     #   mypy
     #   pydantic

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -44,7 +44,7 @@ click==8.1.7
     # via
     #   typer
     #   uvicorn
-coverage[toml]==7.6.8
+coverage==7.6.8
     # via pytest-cov
 distlib==0.3.9
     # via virtualenv
@@ -54,12 +54,12 @@ email-validator==2.2.0
     # via
     #   -r requirements/base.in
     #   fastapi
-fastapi[standard]==0.115.0
+fastapi==0.115.0
     # via
     #   -r requirements/base.in
     #   -r requirements/local.in
     #   pytest-fastapi-deps
-fastapi-cli[standard]==0.0.5
+fastapi-cli==0.0.5
     # via fastapi
 filelock==3.16.1
     # via virtualenv
@@ -236,7 +236,7 @@ urllib3==2.2.3
     # via
     #   botocore
     #   types-requests
-uvicorn[standard]==0.30.6
+uvicorn==0.30.6
     # via
     #   -r requirements/base.in
     #   fastapi


### PR DESCRIPTION
## Title

feat(build): Alter `make lock` so it rebuilds lock files for all environments

### Description

Alters `make lock` so that it rebuilds the lock files for all build environments, not just the one you're currently in.

### Related Issue(s)

Resolves #83 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Acceptance of code changes.

### Testing

Tested in dev enviroment by adding additional dependency to base.in, then checked all `.txt` files to see that that dependency had been added. 
