### PR TITLE
fix(build): Unpin dependencies to allow dependabot to fix security issues

### DIFF
--- a/requirements/action.txt
+++ b/requirements/action.txt
@@ -51,7 +51,7 @@ dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via -r requirements/base.in
-fastapi==0.115.0
+fastapi==0.115.8
     # via
     #   -r requirements/base.in
     #   pytest-fastapi-deps
@@ -183,8 +183,10 @@ sqlalchemy==2.0.37
     #   -r requirements/base.in
     #   alembic
     #   geoalchemy2
-starlette==0.38.6
-    # via fastapi
+starlette==0.45.3
+    # via
+    #   -r requirements/base.in
+    #   fastapi
 types-cachetools==5.5.0.20240820
     # via -r requirements/types.in
 types-pyasn1==0.6.0.20240913

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,14 +3,14 @@
 aiosmtplib >=3.0.0
 alembic >=1.13.2,<2
 asyncer >=0.0.8,<0.0.9
-astropy ==7.0.0
+astropy >=7.0.0
 boto3 >=1.35.17,<2
 cachetools >=5.5.0,<6
 email-validator >=2.2.0,<3
-fastapi ==0.115
-healpy ==1.17.3
+fastapi >=0.115
+healpy >=1.17.3
 httpx >=0.27.2,<0.28
-asyncpg ==0.30.0
+asyncpg >=0.30.0
 shapely >=2.0.6,<3
 sgp4 >=2.23,<3
 sqlalchemy[asyncio] >=2.0.34,<3
@@ -21,3 +21,4 @@ pydantic-settings >=2.5.2,<3
 uvicorn >=0.30.6,<0.31
 astropy-healpix >=1.0.3,<2
 spacetrack >=1.3.1,<2
+starlette>=0.40.0

--- a/requirements/local.in
+++ b/requirements/local.in
@@ -5,4 +5,4 @@
 -r lint.in
 
 # includes the cli
-fastapi[standard] ==0.115
+fastapi[standard] >=0.115

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -56,7 +56,7 @@ email-validator==2.2.0
     # via
     #   -r requirements/base.in
     #   fastapi
-fastapi==0.115.0
+fastapi==0.115.8
     # via
     #   -r requirements/base.in
     #   -r requirements/local.in
@@ -93,7 +93,7 @@ idna==3.10
     #   httpx
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.4
+jinja2==3.1.5
     # via fastapi
 jmespath==1.0.1
     # via
@@ -213,8 +213,10 @@ sqlalchemy==2.0.37
     #   -r requirements/base.in
     #   alembic
     #   geoalchemy2
-starlette==0.38.6
-    # via fastapi
+starlette==0.45.3
+    # via
+    #   -r requirements/base.in
+    #   fastapi
 typer==0.14.0
     # via fastapi-cli
 types-cachetools==5.5.0.20240820

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -45,7 +45,7 @@ dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via -r requirements/base.in
-fastapi==0.115.0
+fastapi==0.115.8
     # via -r requirements/base.in
 geoalchemy2==0.17.0
     # via -r requirements/base.in
@@ -139,8 +139,10 @@ sqlalchemy==2.0.37
     #   -r requirements/base.in
     #   alembic
     #   geoalchemy2
-starlette==0.38.6
-    # via fastapi
+starlette==0.45.3
+    # via
+    #   -r requirements/base.in
+    #   fastapi
 typing-extensions==4.12.2
     # via
     #   alembic


### PR DESCRIPTION
## Title

fix(build): Unpin dependencies to allow dependabot to fix security issues

### Description

A few dependences have hard pins (e.g fastapi) which means that dependabot cannot issue PRs for security issues. One outstanding one is a high security alert on a DDoS using Starlette, which affects any version < 0.40. fastapi is pinned to 0.115, which requires `starlette<0.40`. 

This PR unpins all hard pinned (`==` ) dependencies, to let Dependabot do its job.

It also add a minimum version for `starlette` of `>=0.40.0` in order to resolve the security alert, and remakes the lockfiles with this dependency.

### Related Issue(s)

Resolves #85 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Code review and testing.

### Testing

Ran `make lock` to rebuild lockfiles and confirmed upgrade of `starlette` and `fastapi` to versions without security issues. The updated lockfiles are part of this PR.
