### PR TITLE
fix(tests): Move `mock_global_access` and `mock_self_access` to top level `conftest.py`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,3 +71,18 @@ def mock_webserver_access():
     mock = MagicMock(strategies.webserver_access)
 
     yield mock
+
+
+@pytest.fixture
+def mock_global_access():
+    mock = MagicMock(strategies.global_access)
+
+    yield mock
+
+
+@pytest.fixture
+def mock_self_access():
+    mock = MagicMock(strategies.self_access)
+    mock.id = 1
+
+    yield mock

--- a/tests/service_account/conftest.py
+++ b/tests/service_account/conftest.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -32,21 +32,6 @@ def mock_service_account_service(mock_service_account_data):
     mock.get_many = AsyncMock(return_value=[mock_service_account_data])
     mock.update = AsyncMock(return_value=mock_service_account_data)
     mock.expire_key = AsyncMock(return_value={})
-
-    yield mock
-
-
-@pytest.fixture
-def mock_global_access():
-    mock = MagicMock(strategies.global_access)
-
-    yield mock
-
-
-@pytest.fixture
-def mock_self_access():
-    mock = MagicMock(strategies.self_access)
-    mock.id = 1
 
     yield mock
 


### PR DESCRIPTION
## Title

fix(tests): Move `mock_global_access` and `mock_self_access` to top level `conftest.py`

### Description

pytest fixtures  `mock_global_access` and `mock_self_access`  are defined in the `service_account` tests. However, these are likely to be used in multiple tests in the future (e.g. `mock_global_access` is used by the TLE tests in PR #88). Therefore these should be moved up to the top level `conftest.py` file so they are defined in only one location.

This PR therefore moves these two fixtures to the top-level `conftest.py` file.

### Related Issue(s)

Resolves #96 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Confirmation of testing and acceptance of code style.

### Testing

Run `make test` and confirm tests still work.
