### PR TITLE
fix(group-role): add `group` to prefix, remove unused code

### DIFF
--- a/across_server/routes/group/role/router.py
+++ b/across_server/routes/group/role/router.py
@@ -3,12 +3,11 @@ from typing import Annotated, List
 
 from fastapi import APIRouter, Depends, status
 
-from ....db import models
 from . import schemas
 from .service import GroupRoleService
 
 router = APIRouter(
-    prefix="/{group_id}/role",
+    prefix="/group/{group_id}/role",
     tags=["Group Role"],
     responses={
         status.HTTP_404_NOT_FOUND: {
@@ -16,11 +15,6 @@ router = APIRouter(
         },
     },
 )
-
-
-# replace with security stuff
-async def get_current_user():
-    return models.User(id="173e35fa-9544-49e8-b5b9-d04ea884defb")
 
 
 @router.get(


### PR DESCRIPTION
## fix(group-role): add `group` to prefix, remove unused code

### Description

Group role is missing `group` in prefix.

### Related Issue(s)

#65 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

`group` is in the URL for group roles.

### Testing

1. `make dev`
2. go to localhost:8000/docs
3. see that `group` is part of the group role route
<img width="652" alt="image" src="https://github.com/user-attachments/assets/33af9781-173a-4d02-8173-34d66eb5925e" />

