### PR TITLE
fix(group): add read groups permission

### DIFF
--- a/migrations/seeds/group_roles.py
+++ b/migrations/seeds/group_roles.py
@@ -4,6 +4,7 @@ from across_server.db.models import GroupRole
 
 from .groups import treedome_space_group
 from .permissions import (
+    group_read,
     group_user_write,
     group_write,
     observatory_write,
@@ -13,7 +14,13 @@ from .permissions import (
 treedome_group_admin = GroupRole(
     id=uuid.UUID("f34e9a1b-6843-4dcf-b5a0-12f0d5cb5f45"),
     name="Group Admin",
-    permissions=[group_user_write, group_write, observatory_write, telescope_write],
+    permissions=[
+        group_user_write,
+        group_write,
+        group_read,
+        observatory_write,
+        telescope_write,
+    ],
     group=treedome_space_group,
 )
 

--- a/migrations/seeds/permissions.py
+++ b/migrations/seeds/permissions.py
@@ -8,12 +8,14 @@ all_write = Permission(
     id=uuid.UUID("44cffa7a-b531-48c2-a011-51eb11bea6f4"), name="all:write"
 )
 
+group_read = Permission(id=uuid.uuid4(), name="group:read")
 group_write = Permission(
     id=uuid.UUID("32a6e946-1f29-44d2-a3a7-3c45b5f46499"), name="group:write"
 )
 user_write = Permission(id=uuid.uuid4(), name="user:write")
 service_account_write = Permission(id=uuid.uuid4(), name="user:service_account:write")
 service_account_read = Permission(id=uuid.uuid4(), name="user:service_account:read")
+group_user_read = Permission(id=uuid.uuid4(), name="group:user:read")
 group_user_write = Permission(id=uuid.uuid4(), name="group:user:write")
 observatory_write = Permission(id=uuid.uuid4(), name="group:observatory:write")
 telescope_write = Permission(id=uuid.uuid4(), name="group:telescope:write")
@@ -21,6 +23,7 @@ instrument_write = Permission(id=uuid.uuid4(), name="group:instrument:write")
 
 permissions = [
     all_write,
+    group_read,
     group_write,
     user_write,
     service_account_write,


### PR DESCRIPTION
## fix(group): add read groups permission

### Description

Add `group:read` permission

### Related Issue(s)

#12 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. should be able to get groups with permission

### Testing

1. `make reset`
2. `make dev`
3. go to localhost:8000/docs
4. make call to GET groups
