### PR TITLE
fix(user): add character restrictions to string inputs

### DIFF
--- a/tests/user/schemas_test.py
+++ b/tests/user/schemas_test.py
@@ -1,0 +1,52 @@
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from across_server.routes.user.schemas import UserBase
+
+
+class TestUserBaseSchema:
+    """Test suite for the UserBase schema"""
+
+    def test_schema_data_no_html(self, mock_user_data: dict[str, Any]) -> None:
+        """
+        Should return a validated schema when data has no
+        HTML or other prohibited special characters
+        """
+        mock_user_schema = UserBase(**mock_user_data)
+        assert mock_user_schema.username == mock_user_data["username"]
+
+    def test_schema_data_with_special_character(
+        self, mock_user_data: dict[str, Any]
+    ) -> None:
+        """
+        Should raise a 422 exception when data contains a special character
+        """
+        mock_user_data["username"] = "mockuser!!!"
+        with pytest.raises(HTTPException):
+            UserBase(**mock_user_data)
+
+    def test_schema_data_with_html(self, mock_user_data: dict[str, Any]) -> None:
+        """
+        Should raise a 422 exception when data contains html
+        """
+        mock_user_data["first_name"] = "<b>Mock</b>"
+        with pytest.raises(HTTPException):
+            UserBase(**mock_user_data)
+
+    def test_schema_data_with_dash_allowed(
+        self, mock_user_data: dict[str, Any]
+    ) -> None:
+        """Should return a validated schema when `-` is in the data"""
+        mock_user_data["last_name"] = "User-Person"
+        mock_user_schema = UserBase(**mock_user_data)
+        assert mock_user_schema.last_name == mock_user_data["last_name"]
+
+    def test_schema_data_with_underscore_allowed(
+        self, mock_user_data: dict[str, Any]
+    ) -> None:
+        """Should return a validated schema when `-` is in the data"""
+        mock_user_data["username"] = "mock_user"
+        mock_user_schema = UserBase(**mock_user_data)
+        assert mock_user_schema.username == mock_user_data["username"]


### PR DESCRIPTION
## Title

fix(user): add character restrictions to string inputs

### Description

Adds character restrictions to the string fields for the `UserBase` and `UserUpdate` schemas. This is to prevent users from inputting HTML script tags or other potentially harmful text. 

Big thanks to @jak574 for providing a working example of how to implement this!

### Related Issue(s)

Resolves #100 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

- User creation and update should work when the `first_name`, `last_name`, and `username` fields do not contain any special characters besides `-` and `_`.
- User creation and update should return a `422` status code when attempting to provide a string containing any other special character or HTML tag to any of the above fields.
- Unit tests should pass.

### Testing

1. Run a dev server with `make dev` and navigate to http://127.0.0.1:8000/docs
2. Authorize yourself with `WEBSERVER_SECRET_KEY`
3. Navigate to the `POST` `/user` endpoint and attempt to create a user with a prohibited special character or HTML tag in any of the `first_name`, `last_name`, or `username` fields
4. Verify that you receive a 422 status code in each case
5. Create a user with valid string inputs
6. Use the magic link token in the logs to receive an access token from the `/verify` endpoint, and authorize yourself with that access token
7. Navigate to the `PATCH` `/user` endpoint and attempt to modify a user's fields with a string containing a prohibited special character or HTML tag
8. Verify that you receive a 422 status code
9. Verify that updating a user's fields works with valid string inputs