### PR TITLE
fix(db): UTC time not enforced in database `created_on` and `modified_on`

### DIFF
--- a/across_server/db/models.py
+++ b/across_server/db/models.py
@@ -40,7 +40,9 @@ class CreatableMixin:
         PG_UUID(as_uuid=True), nullable=True
     )
     created_on: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
     )
 
 
@@ -49,7 +51,9 @@ class ModifiableMixin:
         PG_UUID(as_uuid=True), nullable=True
     )
     modified_on: Mapped[datetime | None] = mapped_column(
-        DateTime, nullable=True, onupdate=lambda: datetime.now(timezone.utc)
+        DateTime,
+        nullable=True,
+        onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
     )
 
 


### PR DESCRIPTION
## Title

fix(db): UTC time not enforced in database `created_on` and `modified_on`

### Description

Fixes the behavior of `CreateableMixin` and `ModifiableMixin` to ensure that `created_on` and `modified_on` are written in UTC, regardless of the local timezone setting of the database. Before this if the database was running on a local timezone, those dates were written in the local time zone.

### Related Issue(s)

Resolves #125 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Review of code.

### Testing

I tested in the dev environment, setting the timezone of the local postgis docker container to "America/New York", and ensuring after running `make init` that the `created_on` values of the various seed inputs were indeed in UT time, not local.