### PR TITLE
fix(python): Update code to be uniformly Python 3.12 compliant

### DIFF
--- a/across_server/auth/config.py
+++ b/across_server/auth/config.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from ..core.config import BaseConfig
 
 
@@ -11,7 +9,7 @@ class Config(BaseConfig):
     JWT_ALGORITHM: str = "HS256"
     REFRESH_EXPIRES_IN_DAYS: int = 30
     WEBSERVER_SECRET: str = "WEBSERVER_SECRET_KEY"
-    ALLOWED_IPS: List[str] = ["127.0.0.1"]
+    ALLOWED_IPS: list[str] = ["127.0.0.1"]
 
 
 auth_config = Config()

--- a/across_server/auth/schemas.py
+++ b/across_server/auth/schemas.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, model_serializer
@@ -7,7 +6,7 @@ from pydantic import BaseModel, model_serializer
 
 class Group(BaseModel):
     id: UUID
-    scopes: List[str]
+    scopes: list[str]
 
     @model_serializer
     def serialize(self) -> dict:
@@ -16,10 +15,10 @@ class Group(BaseModel):
 
 class AuthUser(BaseModel):
     id: UUID
-    scopes: List[str]
-    groups: List[Group]
-    first_name: Optional[str] = None
-    last_name: Optional[str] = None
+    scopes: list[str]
+    groups: list[Group]
+    first_name: str | None = None
+    last_name: str | None = None
 
 
 class AccessTokenResponse(BaseModel):

--- a/across_server/auth/security.py
+++ b/across_server/auth/security.py
@@ -1,6 +1,6 @@
 import datetime
 import hashlib
-from typing import Annotated, Optional
+from typing import Annotated
 
 from fastapi import Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -22,7 +22,7 @@ def extract_creds(
 
 
 def generate_secret_key(
-    expiration_duration: int = 30, generator_key: Optional[str] = None
+    expiration_duration: int = 30, generator_key: str | None = None
 ) -> SecretKeySchema:
     now = datetime.datetime.now()
 

--- a/across_server/auth/tokens/access_token.py
+++ b/across_server/auth/tokens/access_token.py
@@ -1,5 +1,3 @@
-from typing import List, Type
-
 from ..config import auth_config
 from ..schemas import AuthUser, Group
 from .base_token import Token, TokenData
@@ -18,15 +16,15 @@ class AccessTokenData(TokenData[str]):
         groups: groups the user belongs to and their associated scopes.
     """
 
-    scopes: List[str]
-    groups: List[Group]
+    scopes: list[str]
+    groups: list[Group]
 
 
 class AccessToken(Token[AccessTokenData, AuthUser]):
     key = auth_config.JWT_SECRET_KEY
 
     @property
-    def data_model(self) -> Type[AccessTokenData]:
+    def data_model(self) -> type[AccessTokenData]:
         return AccessTokenData
 
     def to_encode(self, auth_user: AuthUser):

--- a/across_server/auth/tokens/base_token.py
+++ b/across_server/auth/tokens/base_token.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
-from typing import Generic, Type, TypeVar
+from typing import Generic, TypeVar
 
 import jwt
 from fastapi import HTTPException, status
@@ -35,7 +35,7 @@ class Token(ABC, Generic[T, U]):
 
     @property
     @abstractmethod
-    def data_model(self) -> Type[T]:
+    def data_model(self) -> type[T]:
         """Specifies the Pydantic model that represents the token's data."""
         raise Exception("No data model specified for this token")
 

--- a/across_server/auth/tokens/magic_token.py
+++ b/across_server/auth/tokens/magic_token.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 from pydantic import EmailStr
 
 from ..config import auth_config
@@ -25,7 +23,7 @@ class MagicLinkToken(Token[MagicLinkTokenData, EmailStr]):
     key = auth_config.JWT_MAGIC_LINK_SECRET_KEY
 
     @property
-    def data_model(self) -> Type[MagicLinkTokenData]:
+    def data_model(self) -> type[MagicLinkTokenData]:
         return MagicLinkTokenData
 
     def to_encode(self, email: EmailStr) -> MagicLinkTokenData:

--- a/across_server/auth/tokens/refresh_token.py
+++ b/across_server/auth/tokens/refresh_token.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import Type
 from uuid import UUID
 
 from ..config import auth_config
@@ -24,7 +23,7 @@ class RefreshToken(Token[RefreshTokenData, UUID]):
     key: str = auth_config.JWT_REFRESH_SECRET_KEY
 
     @property
-    def data_model(self) -> Type[RefreshTokenData]:
+    def data_model(self) -> type[RefreshTokenData]:
         return RefreshTokenData
 
     def encode(

--- a/across_server/core/schemas/bandpass.py
+++ b/across_server/core/schemas/bandpass.py
@@ -1,9 +1,7 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
 
 class Bandpass(BaseModel):
-    filter_name: Optional[str]
-    central_wavelength: Optional[float]
-    bandwidth: Optional[float]
+    filter_name: str | None
+    central_wavelength: float | None
+    bandwidth: float | None

--- a/across_server/db/models.py
+++ b/across_server/db/models.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import uuid
 from datetime import datetime, timezone
 from typing import List, Optional, get_args

--- a/across_server/routes/group/role/router.py
+++ b/across_server/routes/group/role/router.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Annotated, List
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 
@@ -22,10 +22,10 @@ router = APIRouter(
     summary="Read group roles",
     description="Read many group roles.",
     status_code=status.HTTP_200_OK,
-    response_model=List[schemas.GroupRole],
+    response_model=list[schemas.GroupRole],
     responses={
         status.HTTP_200_OK: {
-            "model": List[schemas.GroupRole],
+            "model": list[schemas.GroupRole],
             "description": "A list of group roles",
         },
     },

--- a/across_server/routes/group/role/schemas.py
+++ b/across_server/routes/group/role/schemas.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import List
 
 from pydantic import BaseModel, ConfigDict
 
@@ -33,6 +32,6 @@ class User(BaseModel):
 
 
 class GroupRole(GroupRoleRead):
-    users: List[User]
+    users: list[User]
 
     model_config = ConfigDict(from_attributes=True)

--- a/across_server/routes/group/role/service.py
+++ b/across_server/routes/group/role/service.py
@@ -1,4 +1,5 @@
-from typing import Annotated, Sequence
+from collections.abc import Sequence
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends

--- a/across_server/routes/group/router.py
+++ b/across_server/routes/group/router.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Annotated, List
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path, Security, status
 
@@ -29,10 +29,10 @@ async def get_current_user():
     summary="Read groups",
     description="Read many groups.",
     status_code=status.HTTP_200_OK,
-    response_model=List[schemas.Group],
+    response_model=list[schemas.Group],
     responses={
         status.HTTP_200_OK: {
-            "model": List[schemas.Group],
+            "model": list[schemas.Group],
             "description": "A list of groups",
         },
     },

--- a/across_server/routes/group/schemas.py
+++ b/across_server/routes/group/schemas.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import List
 
 from pydantic import BaseModel, ConfigDict
 
@@ -26,11 +25,11 @@ class User(BaseModel):
     last_name: str
     email: str
 
-    group_roles: List[GroupRoleRead]
+    group_roles: list[GroupRoleRead]
 
 
 class Group(GroupRead):
-    users: List["User"]
-    roles: List[GroupRole]
+    users: list["User"]
+    roles: list[GroupRole]
 
     model_config = ConfigDict(from_attributes=True)

--- a/across_server/routes/group/service.py
+++ b/across_server/routes/group/service.py
@@ -1,4 +1,5 @@
-from typing import Annotated, Sequence
+from collections.abc import Sequence
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends

--- a/across_server/routes/observation/schemas.py
+++ b/across_server/routes/observation/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Annotated, ClassVar, Optional
+from typing import Annotated, ClassVar
 
 from pydantic import BeforeValidator, model_validator
 
@@ -39,23 +39,23 @@ class ObservationBase(
     external_observation_id: str
     type: ObservationType
     status: ObservationStatus
-    pointing_angle: Optional[float] = None
-    exposure_time: Optional[float] = None
-    reason: Optional[str] = None
-    description: Optional[str] = None
-    proposal_reference: Optional[str] = None
-    object_position: Optional[Coordinate] = None
-    depth: Optional[UnitValue] = None
-    bandpass: Optional[Bandpass] = None
+    pointing_angle: float | None = None
+    exposure_time: float | None = None
+    reason: str | None = None
+    description: str | None = None
+    proposal_reference: str | None = None
+    object_position: Coordinate | None = None
+    depth: UnitValue | None = None
+    bandpass: Bandpass | None = None
     # Explicit IVOA ObsLocTap
-    t_resolution: Optional[float] = None
-    em_res_power: Optional[float] = None
-    o_ucd: Optional[str] = None
-    pol_states: Optional[str] = None
-    pol_xel: Optional[str] = None
-    category: Optional[IVOAObsCategory] = None
-    priority: Optional[int] = None
-    tracking_type: Optional[IVOAObsTrackingType] = None
+    t_resolution: float | None = None
+    em_res_power: float | None = None
+    o_ucd: str | None = None
+    pol_states: str | None = None
+    pol_xel: str | None = None
+    category: IVOAObsCategory | None = None
+    priority: int | None = None
+    tracking_type: IVOAObsTrackingType | None = None
 
     orm_model: ClassVar = ObservationModel
 
@@ -64,7 +64,7 @@ class Observation(ObservationBase):
     id: uuid.UUID
     schedule_id: uuid.UUID
     created_on: datetime
-    created_by_id: Optional[uuid.UUID] = None
+    created_by_id: uuid.UUID | None = None
 
     @model_validator(mode="before")
     def nest_flattened_jsons(cls, values: dict) -> dict:
@@ -145,8 +145,8 @@ class Observation(ObservationBase):
 
 
 class ObservationCreate(ObservationBase):
-    created_on: Annotated[Optional[datetime], BeforeValidator(convert_to_utc)] = None
-    created_by_id: Optional[uuid.UUID] = None
+    created_on: Annotated[datetime | None, BeforeValidator(convert_to_utc)] = None
+    created_by_id: uuid.UUID | None = None
 
     return_schema: ClassVar = Observation
 

--- a/across_server/routes/role/router.py
+++ b/across_server/routes/role/router.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Annotated, List
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Security, status
 
@@ -28,10 +28,10 @@ async def get_current_user():
     summary="Read roles",
     description="Read many roles.",
     status_code=status.HTTP_200_OK,
-    response_model=List[schemas.Role],
+    response_model=list[schemas.Role],
     responses={
         status.HTTP_200_OK: {
-            "model": List[schemas.Role],
+            "model": list[schemas.Role],
             "description": "A list of roles",
         },
     },

--- a/across_server/routes/role/schemas.py
+++ b/across_server/routes/role/schemas.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import List
 
 from pydantic import BaseModel, ConfigDict
 
@@ -28,10 +27,10 @@ class User(BaseModel):
 
 class Role(RoleBase):
     id: uuid.UUID
-    users: List[User]
+    users: list[User]
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class RoleCreate(RoleBase):
-    permissions: List[str]
+    permissions: list[str]

--- a/across_server/routes/role/service.py
+++ b/across_server/routes/role/service.py
@@ -1,4 +1,5 @@
-from typing import Annotated, Sequence
+from collections.abc import Sequence
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends

--- a/across_server/routes/schedule/schemas.py
+++ b/across_server/routes/schedule/schemas.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Optional
 
 from ...core.enums import ScheduleFidelity, ScheduleStatus
 from ...core.schemas import DateRange
@@ -37,8 +36,8 @@ class ScheduleBase(BaseSchema):
     name: str
     date_range: DateRange
     status: ScheduleStatus
-    external_id: Optional[str] = None
-    fidelity: Optional[ScheduleFidelity] = None
+    external_id: str | None = None
+    fidelity: ScheduleFidelity | None = None
 
 
 class Schedule(ScheduleBase):
@@ -71,10 +70,10 @@ class Schedule(ScheduleBase):
     """
 
     id: uuid.UUID
-    observations: Optional[list[Observation]]
+    observations: list[Observation] | None
     created_on: datetime
-    created_by_id: Optional[uuid.UUID]
-    checksum: Optional[str] = ""
+    created_by_id: uuid.UUID | None
+    checksum: str | None = ""
 
     @staticmethod
     def from_orm(schedule: ScheduleModel) -> Schedule:
@@ -183,14 +182,14 @@ class ScheduleRead(BaseSchema):
 
     """
 
-    date_range_begin: Optional[datetime] = None
-    date_range_end: Optional[datetime] = None
-    status: Optional[ScheduleStatus] = None
-    external_id: Optional[str] = None
-    fidelity: Optional[ScheduleFidelity] = None
-    created_on: Optional[datetime] = None
-    observatory_ids: Optional[list[uuid.UUID]] = []
-    observatory_names: Optional[list[str]] = []
-    telescope_ids: Optional[list[uuid.UUID]] = []
-    telescope_names: Optional[list[str]] = []
-    name: Optional[str] = None
+    date_range_begin: datetime | None = None
+    date_range_end: datetime | None = None
+    status: ScheduleStatus | None = None
+    external_id: str | None = None
+    fidelity: ScheduleFidelity | None = None
+    created_on: datetime | None = None
+    observatory_ids: list[uuid.UUID] | None = []
+    observatory_names: list[str] | None = []
+    telescope_ids: list[uuid.UUID] | None = []
+    telescope_names: list[str] | None = []
+    name: str | None = None

--- a/across_server/routes/tle/service.py
+++ b/across_server/routes/tle/service.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Annotated, Optional
+from typing import Annotated
 
 from fastapi import Depends
 from sqlalchemy import func, literal, select
@@ -43,7 +43,7 @@ class TLEService:
     ) -> None:
         self.db = db
 
-    async def get(self, norad_id: int, epoch: datetime) -> Optional[models.TLE]:
+    async def get(self, norad_id: int, epoch: datetime) -> models.TLE | None:
         """
         Retrieves the closest TLE (Two-Line Element) entry for a given NORAD ID and epoch.
 

--- a/across_server/routes/user/router.py
+++ b/across_server/routes/user/router.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Annotated, List
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 
@@ -23,7 +23,7 @@ router = APIRouter(
 @router.get(
     "/",
     status_code=status.HTTP_200_OK,
-    response_model=List[schemas.User],
+    response_model=list[schemas.User],
 )
 async def get_many(service: Annotated[UserService, Depends(UserService)]):
     return await service.get_many()

--- a/across_server/routes/user/schemas.py
+++ b/across_server/routes/user/schemas.py
@@ -1,9 +1,9 @@
 import re
 import uuid
-from typing import Annotated, List, Optional
+from typing import Annotated
 
 from fastapi import HTTPException, status
-from pydantic import BaseModel, BeforeValidator, ConfigDict, EmailStr
+from pydantic import BaseModel, BeforeValidator, EmailStr
 
 from ...core.schemas import Permission
 from ...core.schemas.base import BaseSchema
@@ -39,20 +39,20 @@ class UserBase(BaseModel):
 class GroupRole(BaseSchema):
     id: uuid.UUID
     name: str
-    permissions: List[Permission]
+    permissions: list[Permission]
 
 
 class Group(BaseSchema):
     id: uuid.UUID
     name: str
     short_name: str
-    roles: List[GroupRole]
+    roles: list[GroupRole]
 
 
 class User(UserBase):
     id: uuid.UUID
-    groups: List[Group]
-    roles: List[RoleBase]
+    groups: list[Group]
+    roles: list[RoleBase]
 
 
 class UserCreate(UserBase):
@@ -60,6 +60,6 @@ class UserCreate(UserBase):
 
 
 class UserUpdate(BaseModel):
-    first_name: Optional[NoHTMLString] = None
-    last_name: Optional[NoHTMLString] = None
-    username: Optional[NoHTMLString] = None
+    first_name: NoHTMLString | None = None
+    last_name: NoHTMLString | None = None
+    username: NoHTMLString | None = None

--- a/across_server/routes/user/service.py
+++ b/across_server/routes/user/service.py
@@ -1,4 +1,5 @@
-from typing import Annotated, Sequence
+from collections.abc import Sequence
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends

--- a/across_server/routes/user/service_account/router.py
+++ b/across_server/routes/user/service_account/router.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Annotated, List
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Security, status
 
@@ -23,7 +23,7 @@ router = APIRouter(
     summary="Read service accounts",
     description="Read many service accounts",
     status_code=status.HTTP_200_OK,
-    response_model=List[schemas.ServiceAccount],
+    response_model=list[schemas.ServiceAccount],
     dependencies=[
         Security(auth.strategies.global_access, scopes=["user:service_account:read"]),
     ],

--- a/across_server/routes/user/service_account/schemas.py
+++ b/across_server/routes/user/service_account/schemas.py
@@ -1,6 +1,6 @@
 import datetime
-import uuid
 from typing import Optional
+import uuid
 
 from ....core.schemas.base import BaseSchema
 
@@ -9,7 +9,7 @@ class ServiceAccount(BaseSchema):
     id: uuid.UUID
     user_id: uuid.UUID
     name: str
-    description: Optional[str]
+    description: str | None
     expiration: datetime.datetime
     expiration_duration: int
     secret_key: str
@@ -17,8 +17,8 @@ class ServiceAccount(BaseSchema):
 
 class ServiceAccountCreate(BaseSchema):
     name: str
-    description: Optional[str]
-    expiration_duration: Optional[int]
+    description: str | None
+    expiration_duration: int | None
 
 
 class ServiceAccountUpdate(BaseSchema):

--- a/across_server/routes/user/service_account/service.py
+++ b/across_server/routes/user/service_account/service.py
@@ -1,5 +1,6 @@
 import datetime
-from typing import Annotated, Sequence
+from collections.abc import Sequence
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends

--- a/across_server/util/create_template.py
+++ b/across_server/util/create_template.py
@@ -1,10 +1,11 @@
-from typing import Callable, Dict, Optional, TypeVar, cast
+from collections.abc import Callable
+from typing import TypeVar, cast
 
-T = TypeVar("T", bound=Dict)
+T = TypeVar("T", bound=dict)
 
 
-def create_template(base: T) -> Callable[[Optional[Dict]], T]:
-    def template(temp: Optional[Dict] = None) -> T:
+def create_template(base: T) -> Callable[[dict | None], T]:
+    def template(temp: dict | None = None) -> T:
         base_copy = cast(T, base.copy())
         if temp:
             base_copy.update(temp)

--- a/across_server/util/decorators/local_only_route.py
+++ b/across_server/util/decorators/local_only_route.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable
 
 from fastapi import APIRouter, HTTPException, status
 

--- a/across_server/util/email/service.py
+++ b/across_server/util/email/service.py
@@ -1,7 +1,6 @@
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import make_msgid
-from typing import List, Optional
 
 import aiosmtplib
 
@@ -66,10 +65,10 @@ class EmailService:
 
     async def send(
         self,
-        recipients: List[str],
+        recipients: list[str],
         subject: str,
-        content_body: Optional[str] = None,
-        content_html: Optional[str] = None,
+        content_body: str | None = None,
+        content_html: str | None = None,
         attachments=[],
     ) -> None:
         em = MIMEMultipart("alternative")

--- a/tests/service_account/conftest.py
+++ b/tests/service_account/conftest.py
@@ -54,7 +54,7 @@ def dep_override(
 
 @pytest.fixture
 def fake_time():
-    return datetime.datetime(1992, 12, 23, 19, 15, 00, tzinfo=datetime.timezone.utc)
+    return datetime.datetime(1992, 12, 23, 19, 15, 00, tzinfo=datetime.UTC)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Title

fix(python): Update code to be uniformly Python 3.12 compliant

### Description

This PR applies changes to the code to make it more compliant with Python 3.12. These changes are applied to `across_server`, but not to migrations. Changes include:

* Removal of `List`, `Dict`, `Type` in typing, in favor of `list`, `dict` and `type`.
* Removal of `Optional` in favor of the `|`.
* Removal of `from typing import Sequence` in favor of `from collections.abc import Sequence`. Importing from `typing` is only necessary for Python<3.9 and can lead to incorrect results (e.g. a `Sequence` will not pass `instance(seq, Sequence)` if `Sequence` is imported from `typing`)
* Same as above but for `Callable`.
* Use of `datetime.timezone.utc` is replaced by `datetime.UTC`.
* The use of `from __future__ import annotations` is removed from `models/db.py` as SQLAlchemy does not at this point fully support forward references for typing. As `db.py` already handles this by putting forward references in quotes, this import is unnecessary. 

### Related Issue(s)

Resolves #128 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Passes testing.

### Testing

Ran pytests. Ran in local dev mode. Operation of across-server unaffected by code-style changes.
