### PR TITLE
fix(tests): fix hanging email service test

### DIFF
--- a/tests/email/service_test.py
+++ b/tests/email/service_test.py
@@ -36,16 +36,12 @@ class TestEmailService:
         self.mocksmtp.sendmail.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_should_throw_error_when_email_fails(self, monkeypatch):
+    async def test_should_throw_error_when_email_fails(self):
         """
         Should throw an error when sending an email fails
-        Ignore the monkeypatched smptlib and instead throw error
-        by attempting to log in using incorrect credentials
         """
-        monkeypatch.undo()
+        self.mocksmtp.sendmail.side_effect = Exception("Mock Exception")
         service = EmailService()
-        service.login_email_user = "mock_user"
-        service.login_email_password = "mock_password"
         with pytest.raises(Exception):
             await service.send(recipients=[self.recipient], subject=self.subject)
 


### PR DESCRIPTION

## fix(tests): fix hanging email service test

### Description

Rewrites the `test_should_throw_error_when_email_fails` `EmailService` unit test to avoid an issue where the test would hang when attempting to login to smptlib with bogus credentials. The new test bypasses the bogus credentials entirely using the monkeypatched smtp client. 

### Related Issue(s)

Resolves #135 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

New unit test should still adequately test error thrown on send without hanging. 

### Testing

1. Do a fresh install of the `across-server` on this branch.
2. Run `make test`
3. Verify `EmailService` tests do not hang.