### PR TITLE
fix(type): Require typed functions/methods in mypy. Add pydantic plugin.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,5 @@ asyncio_mode = "auto"
 
 [tool.mypy]
 files = ["."]
+plugins = ['pydantic.mypy']
+disallow_untyped_defs = true


### PR DESCRIPTION
## Title

fix(type): Require typed functions/methods in mypy. Add pydantic plugin.

### Description

Configures `mypy` to require typing in functions/methods. Without this, untyped functions will just be ignored by mypy, leading to bugs (e.g. like Issue #147).

### Related Issue(s)

Resolves #146 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Team accepts that they need to fix all the missing typing as a result of this change. Upside, this will catch bugs!

### Testing

Ran mypy with this configuration and found lots of flagged issues.
