### PR TITLE
fix(actions): Add `mypy` to list of GitHub actions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,6 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: mypy
+        entry: uv run mypy
         language: system
         types: [python]


### PR DESCRIPTION
## Title

fix(actions): Add mypy to list of GitHub actions

### Description

Run `make tests` as part of the PR actions, so any `mypy` errors that are flagged up cause the tests to fail.

### Related Issue(s)

Resolves #149.

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Shown to work.

### Testing

Committed this PR. `mypy` action ran and failed due to mypy issues in this branch.
