### PR TITLE
fix(types): Remove unnecessary conversion of `UUID` to `str` in `auth/service.py`

### DIFF
--- a/across_server/auth/service.py
+++ b/across_server/auth/service.py
@@ -92,7 +92,7 @@ class AuthService:
                 )
 
                 auth_user.groups.append(
-                    schemas.Group(id=str(group.id), scopes=unique_group_perms)
+                    schemas.Group(id=group.id, scopes=unique_group_perms)
                 )
 
         return auth_user


### PR DESCRIPTION
## Title

fix(types): Remove unnecessary conversion of `UUID` to `str` in `auth/service.py`

### Description

Removes an unnecessary conversion of a `UUID` into a `str` where the argument is expected to be a `UUID`. This error is only picked up by `mypy` if you enable the Pydantic `mypy` plugin, which is handled by PR #148.

### Related Issue(s)

Resolves #153 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Confirmation that everything works as expected.

### Testing

Ran pytests. Ran in dev server. Everything worked.
