### PR TITLE
fix(typing): Fix typing of `Telescope` model `observatory_id` attribute

### DIFF
--- a/across_server/db/models.py
+++ b/across_server/db/models.py
@@ -302,7 +302,7 @@ class Telescope(Base, CreatableMixin, ModifiableMixin):
 
     name: Mapped[str] = mapped_column(String(100))
     short_name: Mapped[str] = mapped_column(String(50), nullable=True)
-    observatory_id: Mapped[int] = mapped_column(
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
         PG_UUID(as_uuid=True), ForeignKey(Observatory.id)
     )
 


### PR DESCRIPTION
## Title

fix(typing): Fix typing of `Telescope` model `observatory_id` attribute

### Description

Fix typing of `Telescope` model `observatory_id` attribute. It should be `UUID` but right now it's `int`. This is a hold over from when id values were integers.

### Related Issue(s)

Resolves #155 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Code review.

### Testing

Ran pytests.
