### PR TITLE
fix(types): Return pydantic schema for /user endpoints

### DIFF
--- a/across_server/core/schemas/permission.py
+++ b/across_server/core/schemas/permission.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
-from pydantic import BaseModel
+from .base import BaseSchema
 
 
-class Permission(BaseModel):
+class Permission(BaseSchema):
     id: UUID
     name: str

--- a/across_server/routes/role/schemas.py
+++ b/across_server/routes/role/schemas.py
@@ -2,8 +2,10 @@ import uuid
 
 from pydantic import BaseModel, ConfigDict
 
+from ...core.schemas.base import BaseSchema
 
-class RoleBase(BaseModel):
+
+class RoleBase(BaseSchema):
     name: str
 
 

--- a/across_server/routes/user/schemas.py
+++ b/across_server/routes/user/schemas.py
@@ -25,7 +25,7 @@ def validate_no_html(value: str) -> str:
 NoHTMLString = Annotated[str, BeforeValidator(validate_no_html)]
 
 
-class UserBase(BaseModel):
+class UserBase(BaseSchema):
     username: NoHTMLString
     first_name: NoHTMLString
     last_name: NoHTMLString


### PR DESCRIPTION
## Title

fix(types): Return pydantic schema for /user endpoints

### Description

Fix `/user` endpoints to return Pydantic schemas instead of SQLAlchemy models. Adds return types to endpoints. Moves schema to inheriting `BaseModel` so they have `from_attributes = True` defined by default (so `model_validate` can ingest SQLA models).

### Related Issue(s)

Resolves #151

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Review of code.

### Testing

Ran pytests. Test endpoints in SwaggerUI.
