### PR TITLE
fix(types): Fix return types for /group endpoints to Pydantic schema

### DIFF
--- a/across_server/routes/group/role/router.py
+++ b/across_server/routes/group/role/router.py
@@ -30,8 +30,11 @@ router = APIRouter(
         },
     },
 )
-async def get_many(service: Annotated[GroupRoleService, Depends(GroupRoleService)]):
-    return await service.get_many()
+async def get_many(
+    service: Annotated[GroupRoleService, Depends(GroupRoleService)],
+) -> list[schemas.GroupRole]:
+    group_role_models = await service.get_many()
+    return [schemas.GroupRole.model_validate(role) for role in group_role_models]
 
 
 @router.get(
@@ -50,5 +53,6 @@ async def get_many(service: Annotated[GroupRoleService, Depends(GroupRoleService
 async def get(
     service: Annotated[GroupRoleService, Depends(GroupRoleService)],
     group_role_id: uuid.UUID,
-):
-    return await service.get(group_role_id)
+) -> schemas.GroupRole:
+    group_role_model = await service.get(group_role_id)
+    return schemas.GroupRole.model_validate(group_role_model)

--- a/across_server/routes/group/role/schemas.py
+++ b/across_server/routes/group/role/schemas.py
@@ -1,9 +1,9 @@
 import uuid
 
-from pydantic import BaseModel, ConfigDict
+from ....core.schemas.base import BaseSchema
 
 
-class GroupRoleBase(BaseModel):
+class GroupRoleBase(BaseSchema):
     name: str
 
 
@@ -23,7 +23,7 @@ class GroupRoleUpdate(GroupRoleBase):
 #   A) parent data should define what data from the child it needs
 #   B) pydantic does not handle circular imports, so even if we
 #      wanted to import the related schema, we can't use it.
-class User(BaseModel):
+class User(BaseSchema):
     id: uuid.UUID
     first_name: str
     last_name: str
@@ -31,7 +31,7 @@ class User(BaseModel):
     email: str
 
 
-class ServiceAccount(BaseModel):
+class ServiceAccount(BaseSchema):
     id: uuid.UUID
     name: str
     description: str | None
@@ -41,5 +41,3 @@ class ServiceAccount(BaseModel):
 class GroupRole(GroupRoleRead):
     users: list[User]
     service_accounts: list[ServiceAccount] | None
-
-    model_config = ConfigDict(from_attributes=True)

--- a/across_server/routes/group/router.py
+++ b/across_server/routes/group/router.py
@@ -4,7 +4,6 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Path, Security, status
 
 from ...auth.strategies import global_access, group_access
-from ...db import models
 from . import schemas
 from .service import GroupService
 
@@ -17,11 +16,6 @@ router = APIRouter(
         },
     },
 )
-
-
-# replace with security stuff
-async def get_current_user():
-    return models.User(id="173e35fa-9544-49e8-b5b9-d04ea884defb")
 
 
 @router.get(
@@ -40,8 +34,9 @@ async def get_current_user():
 )
 async def get_many(
     service: Annotated[GroupService, Depends(GroupService)],
-):
-    return await service.get_many()
+) -> list[schemas.Group]:
+    group_models = await service.get_many()
+    return [schemas.Group.model_validate(group) for group in group_models]
 
 
 @router.get(
@@ -61,5 +56,6 @@ async def get_many(
 async def get(
     service: Annotated[GroupService, Depends(GroupService)],
     group_id: Annotated[uuid.UUID, Path(title="UUID of the group")],
-):
-    return await service.get(group_id)
+) -> schemas.Group:
+    group_model = await service.get(group_id)
+    return schemas.Group.model_validate(group_model)

--- a/across_server/routes/group/schemas.py
+++ b/across_server/routes/group/schemas.py
@@ -1,11 +1,10 @@
 import uuid
 
-from pydantic import BaseModel, ConfigDict
-
+from ...core.schemas.base import BaseSchema
 from .role.schemas import GroupRole, GroupRoleRead
 
 
-class GroupBase(BaseModel):
+class GroupBase(BaseSchema):
     name: str
     short_name: str
 
@@ -18,7 +17,7 @@ class GroupRead(GroupBase):
 #   A) parent data should define what data from the child it needs
 #   B) pydantic does not handle circular imports, so even if we
 #      wanted to import the User schema, we can't use it.
-class User(BaseModel):
+class User(BaseSchema):
     id: uuid.UUID
     username: str
     first_name: str
@@ -31,5 +30,3 @@ class User(BaseModel):
 class Group(GroupRead):
     users: list["User"]
     roles: list[GroupRole]
-
-    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Title

fix(types): Fix return types for /group endpoints to Pydantic schema

### Description

Fixes the returns from `/group/` endpoints from the current returning of SQLAlchemy models, to converting Pydantic schema, as intended.

### Related Issue(s)

Resolves #168 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Correct returns work.

### Testing

Pytests pass. SwaggerUI returns correct values.
