### PR TITLE
fix: Correct return types for `/user/{user_id}/service-account/{service_account_id}/group-role` endpoint

### DIFF
--- a/across_server/routes/user/service_account/group_role/router.py
+++ b/across_server/routes/user/service_account/group_role/router.py
@@ -54,8 +54,8 @@ async def assign(
     )
     group_role = await group_role_service.get(group_role_id)
 
-    service_account = await service.assign(service_account, group_role, user)
-    return schemas.ServiceAccount.model_validate(service_account)
+    role_assigned_account = await service.assign(service_account, group_role, user)
+    return schemas.ServiceAccount.model_validate(role_assigned_account)
 
 
 @router.delete(
@@ -87,5 +87,5 @@ async def remove(
     )
     group_role = await group_role_service.get(group_role_id)
 
-    service_account = await service.remove(service_account, group_role)
-    return schemas.ServiceAccount.model_validate(service_account)
+    role_removed_account = await service.remove(service_account, group_role)
+    return schemas.ServiceAccount.model_validate(role_removed_account)


### PR DESCRIPTION
## Title

fix: Correct return types for `/user/{user_id}/service-account/{service_account_id}/group-role` endpoint

### Description

Fixes the return type of `/user/{user_id}/service-account/{service_account_id}/group-role` endpoints so that they are returning Pydantic Schema rather than SQLAlchemy models. This fixes type errors generated by this mismatch, and generally fixes consistency of how we return to API.

### Related Issue(s)

Resolves #172 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Looks OK.

### Testing

Ran pytests. Tested in Swagger UI.
