### PR TITLE
fix(db): add pre ping parameter to db async engine to resolve database connection reset errors

### DIFF
--- a/across_server/db/database.py
+++ b/across_server/db/database.py
@@ -5,8 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from .config import config
 
 engine = create_async_engine(
-    config.DB_URI(),
-    connect_args={"ssl": "allow"},
+    config.DB_URI(), connect_args={"ssl": "allow"}, pool_pre_ping=True
 )
 
 async_session = async_sessionmaker(


### PR DESCRIPTION
### Description

Fixes the bug when the api server is running but the database connection gets reset due to a database restart.

### Related Issue(s)

Resolves #189

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

The api should continue to serve requests and not surface an Internal Server Error to the user when the database connection is reset while the api server is running.

### Testing

1. Run the API
2. Use any endpoint, such as local-token
3. Reset the database by stopping the docker container and starting it up again
4. Use any endpoint, such as local-token
5. Notice that the server does not surface an Internal Server Error and gracefully resets the connection
