### PR TITLE
chore: remove service_account read and write permission seeds

### DIFF
--- a/migrations/seeds/permissions.py
+++ b/migrations/seeds/permissions.py
@@ -13,8 +13,6 @@ group_write = Permission(
     id=uuid.UUID("32a6e946-1f29-44d2-a3a7-3c45b5f46499"), name="group:write"
 )
 user_write = Permission(id=uuid.uuid4(), name="user:write")
-service_account_write = Permission(id=uuid.uuid4(), name="user:service_account:write")
-service_account_read = Permission(id=uuid.uuid4(), name="user:service_account:read")
 group_user_read = Permission(id=uuid.uuid4(), name="group:user:read")
 group_user_write = Permission(id=uuid.uuid4(), name="group:user:write")
 group_role_write = Permission(id=uuid.uuid4(), name="group:role:write")
@@ -30,8 +28,6 @@ permissions = [
     group_user_write,
     group_role_write,
     user_write,
-    service_account_write,
-    service_account_read,
     observatory_write,
     telescope_write,
     instrument_write,

--- a/migrations/seeds/roles.py
+++ b/migrations/seeds/roles.py
@@ -2,7 +2,7 @@ import uuid
 
 from across_server.db.models import Role
 
-from .permissions import all_write, service_account_read, service_account_write
+from .permissions import all_write
 
 across_admin_role = Role(
     id=uuid.UUID("e81e0a2b-6883-4def-b540-14f0d5cb5f15"),
@@ -10,10 +10,4 @@ across_admin_role = Role(
     permissions=[all_write],
 )
 
-service_account_editor = Role(
-    id=uuid.UUID("fda33adf-1d5b-4b01-878e-90d0c0888e2a"),
-    name="ACROSS Service Account",
-    permissions=[service_account_read, service_account_write],
-)
-
-roles = [across_admin_role, service_account_editor]
+roles = [across_admin_role]

--- a/migrations/seeds/users.py
+++ b/migrations/seeds/users.py
@@ -4,7 +4,7 @@ from across_server.db.models import User
 
 from .group_roles import treedome_group_admin, treedome_schedule_operations
 from .groups import treedome_space_group
-from .roles import across_admin_role, service_account_editor
+from .roles import across_admin_role
 
 dev = User(
     id=uuid.UUID("173e35fa-9544-49e8-b5b9-d04ea884defb"),
@@ -25,7 +25,6 @@ sandy = User(
     last_name="Cheeks",
     created_by_id=None,
     modified_by_id=None,
-    roles=[service_account_editor],
     group_roles=[treedome_group_admin, treedome_schedule_operations],
     groups=[treedome_space_group],
 )


### PR DESCRIPTION
### Description

- Removes database seeds associated with `user:service_account:read` and `user:service_account:write` permission scopes and roles

### Related Issue(s)

Resolves #201 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Permission scopes `user:service_account:write` and `user:service_account:read` are removed

### Testing

1. `make reset`
2. note that migrations and seeding run successfully and the database does not contain the removed permissions
<img width="775" alt="image" src="https://github.com/user-attachments/assets/dcf63bec-d06d-4823-bdd5-cee6915077d2" />
