### PR TITLE
fix(build): Remove option that was causing `make build` to fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ stop_all: check_prod ## Stop all containers
 	@$(DOCKER_COMPOSE) down -v
 
 build: check_prod ## Build the containers (does not run them)
-	@DOCKER_BUILDKIT=1 $(DOCKER_COMPOSE) build --ssh default --build-arg APP_ENV=$(ENV)
+	@DOCKER_BUILDKIT=1 $(DOCKER_COMPOSE) build --build-arg APP_ENV=$(ENV)
 
 restart: ## Restarts the app container
 	@$(DOCKER_COMPOSE) restart


### PR DESCRIPTION
## Title

fix(build): Remove option that was causing `make build` to fail

### Description

`make build` was failing due to a rogue `--ssh default` option in the `docker compose` command.

### Related Issue(s)

Resolves #239 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Needs to fix so that `make build` runs to completion.

### Testing

Run `make build` and observe success.
