### PR TITLE
fix(instrument): Fix instrument search based on telescope ID or name

### DIFF
--- a/across_server/routes/instrument/service.py
+++ b/across_server/routes/instrument/service.py
@@ -88,10 +88,11 @@ class InstrumentService:
             )  # this should/could be a date-range parameter
 
         if data.name:
-            name_lower = str.lower(data.name)
             data_filter.append(
-                func.lower(models.Instrument.name).contains(name_lower)
-                | func.lower(models.Instrument.short_name).contains(name_lower)
+                func.lower(models.Instrument.name).contains(str.lower(data.name))
+                | func.lower(models.Instrument.short_name).contains(
+                    str.lower(data.name)
+                )
             )
 
         if data.telescope_id:


### PR DESCRIPTION
## Title

fix(instrument): Fix instrument search based on telescope ID or name

### Description

Fixes the SQL filter logic for `get_many` Instrument search, allowing to search for instrument based on `telescope_id` and `telescope_name`. The logic in these sqlalchemy code was incorrect and did not work. This PR fixes that.

### Related Issue(s)

Resolves #251 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

The `/instrument` `get_many()` search should be able to return results when searching on `telescope_id` or `telescope_name` without crashing.

### Testing

Test in SwaggerUI with cut and paste names from the `/telescope` endpoint.