### PR TITLE
fix: remove logging middleware in mounted app to prevent dupe logs

### DIFF
--- a/across_server/routes/v1/__init__.py
+++ b/across_server/routes/v1/__init__.py
@@ -1,10 +1,6 @@
-import uuid
-
-from asgi_correlation_id import CorrelationIdMiddleware
 from fastapi import FastAPI
 
-from ... import auth, core
-from ...core.middleware import LoggingMiddleware
+from ... import auth
 from . import (
     group,
     instrument,
@@ -19,19 +15,6 @@ from . import (
 )
 
 api = FastAPI()
-
-api.add_middleware(LoggingMiddleware)
-
-# This middleware must be placed after the logging, to populate the context with the request ID
-# NOTE: Why last??
-# Answer: middlewares are applied in the reverse order of when they are added (you can verify this
-# by debugging `app.middleware_stack` and recursively drilling down the `app` property).
-api.add_middleware(
-    CorrelationIdMiddleware,
-    header_name=core.config.REQUEST_ID_HEADER,
-    update_request_header=True,
-    generator=lambda: uuid.uuid4().hex,
-)
 
 api.include_router(auth.router)
 api.include_router(permission.router)


### PR DESCRIPTION
### Description

Turns out middleware on mounted apps _IS_ shared. Remove adding logging middleware to versioned subapp.

### Related Issue(s)

Resolves #266

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. should output only one log.

### Testing

1. run server
2. hit an endpoint
3. check logs, only 1