### PR TITLE
fix(auth): Fix crash in `/auth/login`, send HTTP exception instead

### DIFF
--- a/across_server/auth/strategies.py
+++ b/across_server/auth/strategies.py
@@ -81,6 +81,12 @@ async def webserver_access(
     request: Request,
     token: Annotated[str, Depends(get_bearer_credentials)],
 ) -> None:
+    if token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     is_webserver = secrets.compare_digest(token, auth_config.WEBSERVER_SECRET)
 
     if request.client:


### PR DESCRIPTION
## Title

fix(auth): Fix crash in `/auth/login`, send HTTP exception instead

### Description

Fix a crash that occurs if `/auth/login/` is accessed without a bearer token. Replaces crash with HTTP Exception 401.

### Related Issue(s)

Resolves #274 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

`/auth/login` endpoints should not cause server crash even if used incorrectly.

### Testing

1. Bring up local server (`make reset` / `make dev`)
2. Use `/auth/login` without entering any auth token.
3. Witness exception 401: Unauthorized. with detail "Missing or invalid token".
