### PR TITLE
bug(router): fixing schedule get many error

### DIFF
--- a/across_server/routes/v1/schedule/router.py
+++ b/across_server/routes/v1/schedule/router.py
@@ -39,10 +39,7 @@ async def get_many(
 ) -> Page[schemas.Schedule]:
     schedule_tuples = await service.get_many(data=data)
 
-    if len(schedule_tuples):
-        total_number = schedule_tuples[0][1]
-    else:
-        total_number = 0
+    total_number = schedule_tuples[0][1] if schedule_tuples else 0
 
     schedules = [tuple[0] for tuple in schedule_tuples]
     return Page[schemas.Schedule].model_validate(
@@ -73,10 +70,7 @@ async def get_history(
 ) -> Page[schemas.Schedule]:
     schedule_tuples = await service.get_history(data=data)
 
-    if len(schedule_tuples):
-        total_number = schedule_tuples[0][1]
-    else:
-        total_number = 0
+    total_number = schedule_tuples[0][1] if schedule_tuples else 0
 
     schedules = [tuple[0] for tuple in schedule_tuples]
     return Page[schemas.Schedule].model_validate(


### PR DESCRIPTION
### Description

Pagination PR introduced a bug in the get many for schedules. If you queried for schedule parameters that returned no records, it would through an indexing error resulting in a Internal Service Error.

### Related Issue(s)

https://github.com/ACROSS-Team/across-server/issues/278

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Querying for schedule data that do not match anything in our database no longer throws a 500.

### Testing

1. Start up the server
2. Put bogus query params into the schedule GET many or GET history
3. Fails gracefully returning a pagination result with no values.