### PR TITLE
fix: add missing backslash command for migrate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ seed: ## Seed the database with initial data (only used on local and dev environ
 
 migrate: ## Run the migrations for the database
 	@if [ -n "$(filter $(ENV), local dev)" ]; then \
-		$(VENV_BIN)/alembic upgrade head
+		$(VENV_BIN)/alembic upgrade head; \
 	else \
 		echo "Migrations are only allowed in runtime ENVs: local, dev."; \
 	fi


### PR DESCRIPTION
### Description

fix: add missing backslash command for migrate

### Related Issue(s)


Resolves #306

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

should run migrate

### Testing

run make migrate

![Uploading image.png…]()
