### PR TITLE
chore: add short name to IDNameSchema

### DIFF
--- a/across_server/core/schemas/base.py
+++ b/across_server/core/schemas/base.py
@@ -25,6 +25,7 @@ class BaseSchema(BaseModel):
 class IDNameSchema(BaseSchema):
     id: UUID
     name: str
+    short_name: str | None
 
 
 class PrefixMixin:

--- a/across_server/routes/v1/instrument/schemas.py
+++ b/across_server/routes/v1/instrument/schemas.py
@@ -71,7 +71,11 @@ class Instrument(InstrumentBase):
             id=obj.id,
             name=obj.name,
             short_name=obj.short_name,
-            telescope=IDNameSchema(id=obj.telescope.id, name=obj.telescope.name),
+            telescope=IDNameSchema(
+                id=obj.telescope.id,
+                name=obj.telescope.name,
+                short_name=obj.telescope.short_name,
+            ),
             footprints=[footprint.polygon for footprint in footprints],
             filters=filters,
             created_on=obj.created_on,

--- a/across_server/routes/v1/telescope/schemas.py
+++ b/across_server/routes/v1/telescope/schemas.py
@@ -63,9 +63,17 @@ class Telescope(TelescopeBase):
             id=obj.id,
             name=obj.name,
             short_name=obj.short_name,
-            observatory=IDNameSchema(id=obj.observatory.id, name=obj.observatory.name),
+            observatory=IDNameSchema(
+                id=obj.observatory.id,
+                name=obj.observatory.name,
+                short_name=obj.observatory.short_name,
+            ),
             instruments=[
-                IDNameSchema(id=instrument.id, name=instrument.name)
+                IDNameSchema(
+                    id=instrument.id,
+                    name=instrument.name,
+                    short_name=instrument.short_name,
+                )
                 for instrument in obj.instruments
             ],
             created_on=obj.created_on,


### PR DESCRIPTION
### Description

Adds a `short_name` field to `IDNameSchema` for `Observatory`, `Telescope`, and `Instrument` objects. This will enable better lookup of telescopes and instruments in `across-data-ingestion`. 

### Related Issue(s)

Resolves #293

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. Should return short name for observatories, telescopes, and instruments on `GET` `/observatory`, `/telescope`, and `/instrument`

### Testing

1. `GET` `/observatory`, `/telescope`, and `/instrument` and verify each route returns the appropriate `short_name` for the relevant objects

I also tested this by running the data ingestion service and verified this does not break any of the current telescope or instrument retrievals from the API