### PR TITLE
fix(db): refresh token on engine connect event

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,8 +38,8 @@
             "env": {
                 "APP_ENV": "across-plat-ue2-dev",
                 "RUNTIME_ENV": "dev",
-                "AWS_PROFILE": "default-mfa",
-                "ACROSS_DB_USER": "core_server"
+                "AWS_PROFILE": "Project-Admin",
+                "ACROSS_DB_USER": "developer"
             },
             "module": "uvicorn",
             "args": [
@@ -50,7 +50,6 @@
                 "--port",
                 "8000"
             ],
-            "jinja": true
         },
         {
             "name": "dev: Migrations",
@@ -64,14 +63,39 @@
             "env": {
                 "APP_ENV": "across-plat-ue2-dev",
                 "RUNTIME_ENV": "dev",
-                "AWS_PROFILE": "default-mfa",
-                "ACROSS_DB_USER": "core_server"
+                "AWS_PROFILE": "Project-Admin",
+                "ACROSS_DB_USER": "developer"
             },
             "module": "alembic",
             "args": [
                 "upgrade",
                 "head"
             ],
+        },
+        {
+            "name": "staging: Start Server",
+            "type": "debugpy",
+            "request": "launch",
+            "envFile": "${workspaceFolder}/.env",
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "pythonArgs": [
+                "-Xfrozen_modules=off"
+            ],
+            "env": {
+                "APP_ENV": "across-plat-ue2-staging",
+                "RUNTIME_ENV": "staging",
+                "ACROSS_DB_USER": "developer",
+                "AWS_PROFILE": "Project-Admin",
+            },
+            "module": "uvicorn",
+            "args": [
+                "across_server.main:app",
+                "--reload",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8000"
+            ]
         },
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 ENV ?= local
 RUNTIME_ENVS = local dev staging prod
 BUILD_ENV ?= local
-BUILD_ENVS = local action deploy test lint format
+BUILD_ENVS = local action deploy
 IS_BUILD_ENV_VALID := $(filter $(BUILD_ENV), $(BUILD_ENVS))
 
 # Docker

--- a/across_server/core/logging.py
+++ b/across_server/core/logging.py
@@ -90,6 +90,8 @@ def setup(json_logs: bool = False, log_level: str = "INFO") -> None:
     # hierarchy (effectively rendering them silent).
     logging.getLogger("uvicorn.access").handlers.clear()
     logging.getLogger("uvicorn.access").propagate = False
+    logging.getLogger("boto3").setLevel(logging.INFO)
+    logging.getLogger("botocore").setLevel(logging.INFO)
 
     def handle_exception(
         exc_type: type[BaseException],

--- a/across_server/db/config.py
+++ b/across_server/db/config.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING
+
 import boto3
 import structlog
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from sqlalchemy import URL
+
+if TYPE_CHECKING:
+    from types_boto3_sts import type_defs as sts
 
 from ..core.config import config as core_config
 from ..util.ssm import SSM
@@ -10,7 +15,7 @@ logger: structlog.stdlib.BoundLogger = structlog.get_logger()
 
 
 class Config(BaseSettings):
-    ACROSS_DB_USER: str = "user"
+    ACROSS_DB_USER: str = "admin"
     ACROSS_DB_PWD: str = "local"
     ACROSS_DB_NAME: str = "across"
     ACROSS_DB_HOST: str = "localhost"
@@ -19,54 +24,30 @@ class Config(BaseSettings):
 
     DRIVER_NAME: str = "postgresql+asyncpg"
 
-    _cluster_name: str = f"{core_config.APP_ENV}-core-server-db"
+    def __init__(self) -> None:
+        super().__init__()
 
-    def DB_URI(self) -> URL:
         if core_config.is_local():
-            return self._get_local_uri()
+            self._uri = self._get_local_uri()
         else:
-            return self._get_aurora_uri()
+            self._cluster_name = f"{core_config.APP_ENV}-core-server-db"
+            self._ssm_path = f"/aurora-postgres/{self._cluster_name}"
+            self._cluster_port = int(SSM.get_parameter("db_port", self._ssm_path))
+            cluster_domain = SSM.get_parameter("cluster_domain", self._ssm_path)
 
-    def _get_ssm_path(self) -> str:
-        return f"/aurora-postgres/{self._cluster_name}"
+            self._cluster_host = "".join(
+                [self._cluster_name, ".cluster-", cluster_domain]
+            )
 
-    def _get_local_uri(self) -> URL:
-        return URL.create(
-            drivername=self.DRIVER_NAME,
-            username=self.ACROSS_DB_USER,
-            password=self.ACROSS_DB_PWD,
-            host=self.ACROSS_DB_HOST,
-            port=self.ACROSS_DB_PORT,
-            database=self.ACROSS_DB_NAME,
-        )
+            self._uri = self._get_aurora_uri()
 
-    def _get_aurora_uri(self) -> URL:
-        ssm_db_path = self._get_ssm_path()
-        cluster_domain = SSM.get_parameter("cluster_domain", ssm_db_path)
+    @property
+    def DB_URI(self) -> URL:
+        return self._uri
 
-        host = "".join([self._cluster_name, ".cluster-", cluster_domain])
-        port = int(SSM.get_parameter("db_port", ssm_db_path))
-        token = self._get_rds_token(host, port)
-
-        return URL.create(
-            drivername=self.DRIVER_NAME,
-            username=self.ACROSS_DB_USER,
-            password=token,
-            host=host,
-            port=port,
-            database=self.ACROSS_DB_NAME,
-        )
-
-    def _get_rds_token(self, host: str, port: int) -> str:
-        # Assume DB access Role
-        sts = boto3.client("sts")
-        identity = sts.get_caller_identity()
-        account_id = identity["Account"]
-        username = identity["Arn"].split("/")[-1]
-        role_arn = f"arn:aws:iam::{account_id}:role/{core_config.APP_ENV}-{self.ACROSS_DB_ROLE_NAME}"
-        response = sts.assume_role(RoleArn=role_arn, RoleSessionName=username)
-
-        creds = response["Credentials"]
+    def get_iam_rds_token(self) -> str:
+        role = self._assume_role()
+        creds = role["Credentials"]
 
         # Generate temporary IAM Auth Token
         rds = boto3.client(
@@ -77,7 +58,47 @@ class Config(BaseSettings):
         )
 
         return rds.generate_db_auth_token(
-            DBHostname=host, Port=port, DBUsername=self.ACROSS_DB_USER
+            DBHostname=self._cluster_host,
+            Port=self._cluster_port,
+            DBUsername=self.ACROSS_DB_USER,
+        )
+
+    def _assume_role(self) -> "sts.AssumeRoleResponseTypeDef":
+        sts = boto3.client("sts")
+        identity = sts.get_caller_identity()
+        account_id = identity["Account"]
+
+        # username is parsed from the end of the ARN
+        username = identity["Arn"].split("/")[-1]
+
+        # construct the role ARN
+        role_arn = f"arn:aws:iam::{account_id}:role/{core_config.APP_ENV}-{self.ACROSS_DB_ROLE_NAME}"
+
+        return sts.assume_role(
+            RoleArn=role_arn,
+            RoleSessionName=username,
+        )
+
+    def _get_aurora_uri(self) -> URL:
+        token = self.get_iam_rds_token()
+
+        return URL.create(
+            drivername=self.DRIVER_NAME,
+            username=self.ACROSS_DB_USER,
+            password=token,
+            host=self._cluster_host,
+            port=self._cluster_port,
+            database=self.ACROSS_DB_NAME,
+        )
+
+    def _get_local_uri(self) -> URL:
+        return URL.create(
+            drivername=self.DRIVER_NAME,
+            username=self.ACROSS_DB_USER,
+            password=self.ACROSS_DB_PWD,
+            host=self.ACROSS_DB_HOST,
+            port=self.ACROSS_DB_PORT,
+            database=self.ACROSS_DB_NAME,
         )
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")

--- a/across_server/db/database.py
+++ b/across_server/db/database.py
@@ -1,6 +1,8 @@
 from collections.abc import AsyncGenerator
+from typing import Tuple
 
 import structlog
+from sqlalchemy import Dialect, event, pool
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -17,6 +19,18 @@ engine: AsyncEngine
 async_session: async_sessionmaker
 
 
+# see: https://docs.sqlalchemy.org/en/20/core/events.html#sqlalchemy.events.DialectEvents.do_connect
+def refresh_token(
+    _dialect: Dialect,
+    _conn_rec: pool.ConnectionPoolEntry,
+    _cargs: Tuple,
+    cparams: dict,
+) -> None:
+    logger.debug("Refreshing RDS IAM Auth token")
+    cparams["password"] = config.get_iam_rds_token()
+    logger.debug("Token Refreshed, connecting...")
+
+
 def init() -> None:
     """
     Initialize database engine and sessionmaker
@@ -25,21 +39,22 @@ def init() -> None:
     global engine
     global async_session
 
-    try:
-        engine = create_async_engine(
-            url=config.DB_URI(),
-            pool_pre_ping=True,
-            connect_args={"ssl": "require" if not core_config.is_local() else "allow"},
-        )
+    engine = create_async_engine(
+        url=config.DB_URI,
+        pool_pre_ping=True,
+        connect_args={"ssl": "require" if not core_config.is_local() else False},
+    )
+    logger.debug("Created async db engine")
 
-        async_session = async_sessionmaker(
-            autocommit=False,
-            expire_on_commit=False,
-            autoflush=False,
-            bind=engine,
-        )
-    except Exception as err:
-        logger.error("Unknown error while initializing the database.", err=err)
+    async_session = async_sessionmaker(
+        autocommit=False,
+        expire_on_commit=False,
+        autoflush=False,
+        bind=engine,
+    )
+    logger.debug("Created async db session")
+
+    event.listen(engine.sync_engine, "do_connect", refresh_token)
 
 
 async def get_session() -> AsyncGenerator[AsyncSession]:

--- a/docker/compose.local.yml
+++ b/docker/compose.local.yml
@@ -1,4 +1,4 @@
-name: across-server
+name: core-server
 
 services:
   app:
@@ -9,10 +9,11 @@ services:
       ssh:
         - default
     volumes:
-      - ./across_server/main.py:/app/across_server/main.py
-      - ./across_server:/app/across_server
+      - ../across_server/main.py:/app/across_server/main.py
+      - ../across_server:/app/across_server
     environment:
       BUILD_ENV: local
+      ACROSS_DB_HOST: db
     command: fastapi dev across_server/main.py --host 0.0.0.0 --port 8000
     ports:
       - 8000:8000

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -45,7 +45,7 @@ def include_name(name: Any, type_: Any | None, parent_names: Any) -> bool:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
 logger.info(f"Running migration for '{core_config.APP_ENV}'.")
-DATABASE_URL = config.DB_URI()
+DATABASE_URL = config.DB_URI
 
 
 def run_migrations_offline() -> None:

--- a/migrations/seed.py
+++ b/migrations/seed.py
@@ -49,7 +49,7 @@ seed_order: list[tuple[Type[DeclarativeBase], Sequence[DeclarativeBase]]] = [
 
 
 async def seed() -> None:
-    engine = create_async_engine(config.DB_URI())
+    engine = create_async_engine(config.DB_URI)
 
     async_session = async_sessionmaker(engine, expire_on_commit=False)
 


### PR DESCRIPTION
### Description

Once the connection is established, it will remain open indefinitely, see sqlalchemy docs on recycling connections.

However, if there is inactivity on the DB, then Aurora drops the ACUs to 0, effectively "closing" the DB connection. The server is still expecting the connection to be alive, and but only connects again with the same token that is expired. Notice in the testing there is a delay, this varies between 5-10s each time a new connection has to be made with a new token. If we find this to be an issue then we can relatively simply circumvent this with the usage of a locked down user (same perms as the `core_server` from [this infra PR](https://github.com/ACROSS-Team/across-infrastructure/pull/31)) that will use a user/pw that is managed by AWS secrets similarly to how the db admin is generated.

This was verified by checking `"connect"` event which happens directly after the connection is established. 

This seems to be a direct limitation of using RDS IAM Auth. This should _rarely_ happen though since prod ACU will likely _NOT_ be set to 0. Also, the big assumption here is that when the ACU drops to 0, the db connection is dropped/closed as well, we can test this as well to see if we get some lag on requests to the server after about ~2-3 hours of inactivity. It is not immediately clear when this happens.

Misc:
 - fixed local docker-compose
 - added launch.json for staging env

### Related Issue(s)

Resolves #313

### Reviewers
@ACROSS-Team/developers 

### Acceptance Criteria

should refresh the token on new connections.
should not return PAM auth failure on stale connections.

### Testing

Difficult to repro the actual PAM auth bug, however, it can be seen that the event is triggered and the token gets refreshed.

1. launch `dev: Start Server`
2. execute 
```shell
curl -X 'GET' \
  'http://localhost:8000/api/v1/permission/' \
  -H 'accept: application/json'
  ```
  3. check local logs:
  ```shell
  2025-07-24T22:20:09.319098 [debug    ] Refreshing RDS IAM Auth token  [across_server.db.database] request_id=f75236ed320e4341b77ef6c4132988ef
2025-07-24T22:20:09.327968 [debug    ] Starting new HTTPS connection (1): sts.amazonaws.com:443 [urllib3.connectionpool] request_id=f75236ed320e4341b77ef6c4132988ef
2025-07-24T22:20:09.938026 [debug    ] https://sts.amazonaws.com:443 "POST / HTTP/11" 200 498 [urllib3.connectionpool] request_id=f75236ed320e4341b77ef6c4132988ef
2025-07-24T22:20:10.065453 [debug    ] https://sts.amazonaws.com:443 "POST / HTTP/11" 200 1105 [urllib3.connectionpool] request_id=f75236ed320e4341b77ef6c4132988ef
2025-07-24T22:20:20.596859 [info     ] 127.0.0.1:59914 - "GET /api/v1/permission/ HTTP/1.1" 200 [across_server.core.middleware.logging] duration=11285311500 http={'url': 'http://localhost:8000/api/v1/permission/', 'status_code': 200, 'method': 'GET', 'version': '1.1'} network={'client': {'ip': '127.0.0.1', 'port': 59914}} request_id=f75236ed320e4341b77ef6c4132988ef
```