### PR TITLE
fix: refresh_token should happen for non-local only

### DIFF
--- a/across_server/db/database.py
+++ b/across_server/db/database.py
@@ -54,7 +54,8 @@ def init() -> None:
     )
     logger.debug("Created async db session")
 
-    event.listen(engine.sync_engine, "do_connect", refresh_token)
+    if not core_config.is_local():
+        event.listen(engine.sync_engine, "do_connect", refresh_token)
 
 
 async def get_session() -> AsyncGenerator[AsyncSession]:


### PR DESCRIPTION
### Description
RDS refresh_token is called on local env, it shoudl not be.

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

should be able to use local without calling AWS

### Testing

run server locally,
call any route that hits the DB.
