### PR TITLE
fix(build): fix Makefile path for pre-commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ install: check_env venv ## Install dependencies from the lockfile for the specif
 install_hooks: ## Install 'pre-commit' git hooks, only for local.
 	@if [ $(ENV) == local ]; then \
 		echo "Installing pre-commit git hooks..."; \
-		$(VENV_DIR)/pre-commit install; \
+		$(VENV_BIN)/pre-commit install; \
 	else \
 		echo "Not a git repository. Skipping pre-commit hooks installation."; \
 	fi


### PR DESCRIPTION
## Title

fix(build): fix Makefile path for pre-commit
### Description

This pull request makes a small change to the `Makefile` to fix the path used for installing pre-commit git hooks. The update ensures that the correct binary directory is referenced when running the install command.

### Related Issue(s)

Resolves #327 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Make install should not fail at the step that installs the `pre-commit` git hook.

### Testing

Test by running `make install` and seeing that it does not crash.