### PR TITLE
fix: user can update own information when user has group invitation

### DIFF
--- a/across_server/routes/v1/user/router.py
+++ b/across_server/routes/v1/user/router.py
@@ -114,6 +114,10 @@ async def update(
     data: schemas.UserUpdate,
 ) -> schemas.User:
     user_model = await service.update(user_id, data, modified_by=auth_user)
+
+    for invite in user_model.received_invites:
+        await invite.awaitable_attrs.sender
+
     return schemas.User.model_validate(user_model)
 
 


### PR DESCRIPTION
### Description

This PR addresses a bug where users could not update their own information if they had a group invitation.

### Related Issue(s)

Resolves #329 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

- A user should be able to edit their user information by utilizing the Profile in the frontend or using PATCH /user/{user_id} when they have a group invitation.

### Testing

1. Create a new user `ekrabs@treedome.space`
2. Log in as `sandy@treedome.space`
3. Send the new user an invitation to Treedome Space Group
4. Log in as the new user `ekrabs@treedome.space`
5. Visit Profile on the frontend to edit user information or send a request to the API via PATCH /user/{user_id} 
6. Server should return a 200 and your information should be updated in the database 🎉 
