### PR TITLE
feat(routes): add instrument schema to GET Telescope

### DIFF
--- a/across_server/routes/v1/telescope/router.py
+++ b/across_server/routes/v1/telescope/router.py
@@ -60,4 +60,11 @@ async def get_many(
     data: Annotated[schemas.TelescopeRead, Query()],
 ) -> list[schemas.Telescope]:
     telescopes = await service.get_many(data=data)
-    return [schemas.Telescope.from_orm(telescope) for telescope in telescopes]
+    return [
+        schemas.Telescope.from_orm(
+            telescope,
+            include_footprints=data.include_footprints,
+            include_filters=data.include_filters,
+        )
+        for telescope in telescopes
+    ]

--- a/across_server/routes/v1/telescope/schemas.py
+++ b/across_server/routes/v1/telescope/schemas.py
@@ -4,8 +4,11 @@ import uuid
 from datetime import datetime
 
 from ....core.schemas.base import BaseSchema, IDNameSchema
+from ....db.models import Instrument as InstrumentModel
 from ....db.models import Telescope as TelescopeModel
-from ..instrument.schemas import Instrument
+from ..filter.schemas import Filter
+from ..footprint.schemas import Footprint
+from ..instrument.schemas import InstrumentBase
 
 
 class TelescopeBase(BaseSchema):
@@ -31,7 +34,7 @@ class TelescopeBase(BaseSchema):
     name: str
     short_name: str
     observatory: IDNameSchema | None = None
-    instruments: list[Instrument] | None = None
+    instruments: list[TelescopeInstrument] | None = None
 
 
 class Telescope(TelescopeBase):
@@ -49,7 +52,12 @@ class Telescope(TelescopeBase):
     """
 
     @classmethod
-    def from_orm(cls, obj: TelescopeModel) -> Telescope:
+    def from_orm(
+        cls,
+        obj: TelescopeModel,
+        include_footprints: bool = True,
+        include_filters: bool = True,
+    ) -> Telescope:
         """
         Method that converts a models.Telescope record to a schemas.Telescope
         Parameters
@@ -70,7 +78,10 @@ class Telescope(TelescopeBase):
                 short_name=obj.observatory.short_name,
             ),
             instruments=[
-                Instrument.from_orm(instrument) for instrument in obj.instruments
+                TelescopeInstrument.from_orm(
+                    instrument, include_footprints, include_filters
+                )
+                for instrument in obj.instruments
             ],
             created_on=obj.created_on,
         )
@@ -95,3 +106,56 @@ class TelescopeRead(BaseSchema):
     instrument_id: uuid.UUID | None = None
     instrument_name: str | None = None
     created_on: datetime | None = None
+    include_filters: bool = False
+    include_footprints: bool = False
+
+
+class TelescopeInstrument(InstrumentBase):
+    """
+    A Pydantic model class representing a created Instrument for the Telescope Endpoint
+
+    Notes
+    -----
+    Inherits from InstrumentBase
+
+    Methods
+    -------
+    from_orm(instrument: InstrumentModel, include_footprints: bool, include_filters: bool) -> Instrument
+        Static method that instantiates this class from a Instrument database record
+    """
+
+    @classmethod
+    def from_orm(
+        cls,
+        obj: InstrumentModel,
+        include_footprints: bool = True,
+        include_filters: bool = True,
+    ) -> TelescopeInstrument:
+        """
+        Method that converts a models.Instrument record to a schemas.Instrument
+        Parameters
+        ----------
+        Telescope: TelescopeModel
+            the models.Telescope record
+        Returns
+        -------
+            schemas.Telescope
+        """
+        footprints = [Footprint.from_orm(footprint) for footprint in obj.footprints]
+        filters = [Filter.model_validate(filter) for filter in obj.filters]
+
+        return cls(
+            id=obj.id,
+            name=obj.name,
+            short_name=obj.short_name,
+            telescope=IDNameSchema(
+                id=obj.telescope.id,
+                name=obj.telescope.name,
+                short_name=obj.telescope.short_name,
+            ),
+            footprints=[footprint.polygon for footprint in footprints]
+            if include_footprints
+            else [],
+            filters=filters if include_filters else [],
+            created_on=obj.created_on,
+        )


### PR DESCRIPTION
### Description

This PR adds the full instrument schema to the GET Telescope route endpoint.

**A note**: This is a simplest solution approach. I just replaced the `IDNameSchema` for the `Telescope.Instruments` list to be a list of the Instrument GET schema. A result of this is that it recursively provides the Telescope `IDNameSchema` in the result. It looks kind of redundant. If preferred I can change the result to not include the Telescope `IDNameSchema` in the instruments list.

### Related Issue(s)

#315 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

GET Telescope returns comprehensive instrument information

### Testing

1. `make dev`
2. perform a GET Telescope in the docs - returns full instrument information that belong to the telescope(s).
