### PR TITLE
fix(deploy): env var values must be strings

### DIFF
--- a/deploy/taskdef.json
+++ b/deploy/taskdef.json
@@ -6,19 +6,19 @@
             "environment": [
                 {
                     "name": "LIMIT_TOKEN_REQUESTS_PER_MINUTE",
-                    "value": 5
+                    "value": "5"
                 },
                 {
                     "name": "LIMIT_DEFAULT_REQUESTS_PER_MINUTE",
-                    "value": 30
+                    "value": "30"
                 },
                 {
                     "name": "LIMIT_USER_REQUESTS_PER_SECOND",
-                    "value": 5
+                    "value": "5"
                 },
                 {
                     "name": "LIMIT_SERVICE_ACCOUNT_REQUESTS_PER_SECOND",
-                    "value": 10
+                    "value": "10"
                 }
             ]
         }


### PR DESCRIPTION
### Description
fix this error in deployment: https://github.com/ACROSS-Team/across-server/actions/runs/17776327946/job/50524981237#step:10:497