### PR TITLE
fix(schedule): sort by created_on DESC

### DIFF
--- a/across_server/routes/v1/schedule/service.py
+++ b/across_server/routes/v1/schedule/service.py
@@ -225,6 +225,7 @@ class ScheduleService:
             select(models.Schedule, func.count().over().label("count"))
             .filter(*schedule_filter)
             .distinct(
+                models.Schedule.created_on,
                 models.Schedule.date_range_begin,
                 models.Schedule.date_range_end,
                 models.Schedule.status,
@@ -232,12 +233,12 @@ class ScheduleService:
                 models.Schedule.telescope_id,
             )
             .order_by(
+                models.Schedule.created_on.desc(),
                 models.Schedule.date_range_begin,
                 models.Schedule.date_range_end,
                 models.Schedule.status,
                 models.Schedule.fidelity,
                 models.Schedule.telescope_id,
-                models.Schedule.created_on.desc(),
             )
             .limit(data.page_limit)
             .offset(data.offset)


### PR DESCRIPTION
### Description

This PR fixes an issue with the GET /schedule/ response sorting by created_on incorrectly.

### Related Issue(s)

Resolves #352 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

GET /schedule/ should sort by created_on DESC

### Testing

1. run the server
2. visit http://localhost:8000/api/v1/schedule/?telescope_ids=653e6456-2cb0-49da-a6be-7c7ed69c0cb5 to query TESS schedules
3. you will see that schedules are sorted by created_on DESC
