### PR TITLE
fix(tle): add system permission to enable system role to write TLE

### DIFF
--- a/across_server/auth/strategies.py
+++ b/across_server/auth/strategies.py
@@ -27,7 +27,7 @@ async def authenticate_jwt(
 
 async def global_access(
     security_scopes: SecurityScopes,
-    auth_user: Annotated[AuthUser, Depends(authenticate)],
+    auth_user: Annotated[AuthUser, Depends(authenticate_jwt)],
 ) -> AuthUser:
     if system_access(auth_user):
         return auth_user

--- a/across_server/routes/v1/tle/router.py
+++ b/across_server/routes/v1/tle/router.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Security, status
 
 from .... import auth
 from . import schemas
@@ -27,7 +27,7 @@ router = APIRouter(
         status.HTTP_201_CREATED: {},
     },
     response_model=schemas.TLE,
-    dependencies=[Depends(auth.strategies.global_access)],
+    dependencies=[Security(auth.strategies.global_access, scopes=["system:tle:write"])],
 )
 async def create(
     TLE_service: Annotated[TLEService, Depends(TLEService)],

--- a/migrations/versions/_2025_09_18_1454-59faf999b470_add_tle_scope_to_system_role.py
+++ b/migrations/versions/_2025_09_18_1454-59faf999b470_add_tle_scope_to_system_role.py
@@ -1,0 +1,52 @@
+"""add tle scope to system role
+
+Revision ID: 59faf999b470
+Revises: d829f34da2f8
+Create Date: 2025-09-18 14:54:15.847131
+
+"""
+
+from typing import Sequence, Union
+from uuid import UUID
+
+from alembic import op
+from sqlalchemy import orm
+
+import migrations.versions.model_snapshots.models_2025_09_02 as models
+
+# revision identifiers, used by Alembic.
+revision: str = "59faf999b470"
+down_revision: Union[str, None] = "d829f34da2f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+tle_permission_values = {
+    "name": "system:tle:write",
+    "id": UUID("f210ab41-7066-410f-ae08-c8916d4b1c0a"),
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    session = orm.Session(bind=bind, expire_on_commit=False)
+
+    # system role by uuid from db
+    system_role: models.Role = session.get(
+        models.Role, UUID("ed6a2440-79c8-454a-8284-f826a27f6e04"), with_for_update=True
+    )  # type: ignore
+    # add permission
+    system_role.permissions.append(models.Permission(**tle_permission_values))
+
+    session.commit()
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    session = orm.Session(bind=bind, expire_on_commit=False)
+
+    tle_permission: models.Permission = session.get(
+        models.Permission, tle_permission_values["id"]
+    )  # type: ignore
+    session.delete(tle_permission)
+
+    session.commit()

--- a/migrations/versions/model_snapshots/models_2025_09_02.py
+++ b/migrations/versions/model_snapshots/models_2025_09_02.py
@@ -531,6 +531,9 @@ class ScheduleCadence(Base, CreatableMixin, ModifiableMixin):
     )
     schedule_status: Mapped[str] = mapped_column(String(50), nullable=False)
     cron: Mapped[str] = mapped_column(String(50), nullable=True)
+    telescope: Mapped["Telescope"] = relationship(
+        back_populates="schedule_cadences", lazy="selectin"
+    )
 
 
 class Observation(Base, CreatableMixin, ModifiableMixin):


### PR DESCRIPTION
### Description

This PR adjusts the `global_access` auth strategy to use `authenticate_jwt` which is able to authenticate both service account and user JWT types. Additionally, this PR adds the `system:tle:write` permission for our system service account to be able to pass authorization to POST tles from data-ingestion.

BONUS BUG FIX:
model snapshot was missing `telescopes` backref which was failing to run the new migration, broken in my previous PR, fixed here.

### Related Issue(s)

Resolves #343 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Running across-data-ingestion with the TLE task should POST /tle/ data to across-server

### Testing

- pull this branch
- run migrations and start the server `make migrate && make dev`
- run across-data-ingestion with _only_ the TLE task
- you should see 201 responses from the server
<img width="1243" height="563" alt="image" src="https://github.com/user-attachments/assets/4caee91c-55c9-43eb-b9a4-bbbe462c7f9e" />

