### PR TITLE
fix: deployed api docs URL matches currently deployed environment

### DIFF
--- a/across_server/core/config.py
+++ b/across_server/core/config.py
@@ -43,7 +43,10 @@ class Config(BaseConfig):
         return self.RUNTIME_ENV == Environments.LOCAL
 
     def base_url(self) -> str:
-        return f"{self.HOST}:{self.PORT}{self.ROOT_PATH}"
+        if self.is_local():
+            return f"{self.HOST}:{self.PORT}{self.ROOT_PATH}"
+        else:
+            return f"https://server.{self.RUNTIME_ENV.value}.across.smce.nasa.gov{self.ROOT_PATH}"
 
 
 config = Config()


### PR DESCRIPTION
### Description

This PR addresses the incorrect link that appears in deployed environments pointing to a localhost address.

### Related Issue(s)

Resolves #277

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Deployed environments should present the correct link to see `V1 Docs`

### Testing

This PR can be run locally to test using aws credentials by running a `dev` env server

1. `aws sso login` be sure your profile name matches the `AWS_PROFILE` in `.vscode/launch.json`
2. run `dev: Start Server`
   <img width="327" height="50" alt="image" src="https://github.com/user-attachments/assets/531d5ae7-1653-4316-aa5f-07972f156b39" />
3. visit http://127.0.0.1:8000/docs
4. you should see that the `V1 Docs` link presents the correct URL for the `dev` environment
   <img width="808" height="589" alt="image" src="https://github.com/user-attachments/assets/918e3068-5be0-4854-8e04-4d6ff4710293" />

