### PR TITLE
fix: add self_access authorization strategy to delete user route

### DIFF
--- a/across_server/routes/v1/user/router.py
+++ b/across_server/routes/v1/user/router.py
@@ -138,6 +138,7 @@ async def update(
             "description": "Upon successful deletion, the user is returned",
         },
     },
+    dependencies=[Depends(auth.strategies.self_access)],
 )
 async def delete(
     service: Annotated[UserService, Depends(UserService)],


### PR DESCRIPTION
### Description

Adds self_access authorization dependency for the DELETE user route

### Related Issue(s)

Resolves #264 

We will implement user soft deletes in a follow up PR, issue ref: https://github.com/ACROSS-Team/across-server/issues/358

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Unauthenticated and Unauthorized users cannot delete user entities
Only a registered user authenticated as themselves can access the delete user route for their user id

### Testing

1. Run the server
2. [attempt to DELETE sandy's user](http://localhost:8000/api/v1/docs#/User/delete_user) id `e2c834a4-232c-420a-985e-eb5bc59aba24`
3. The request should fail with 
   <img width="326" height="173" alt="image" src="https://github.com/user-attachments/assets/ec23e9f8-9f42-40d1-b41d-87312b785b58" />
4. [get a local token](http://localhost:8000/api/v1/docs#/Auth/local_token_auth_local_token_get) for `sandy@treedome.space` and authorize the swagger ui
5. [repeat the attempt to DELETE sandy's user](http://localhost:8000/api/v1/docs#/User/delete_user) id `e2c834a4-232c-420a-985e-eb5bc59aba24`
6. the request should succeed!
   <img width="588" height="324" alt="image" src="https://github.com/user-attachments/assets/76938e68-5a53-4d39-be67-19976892a811" />
7. Subsequent requests with sandy's user token should respond with `"Unauthorized"` since the user uuid as the token.sub cannot be found
8. Run `make seed` locally to restore sandy's user [then query for the user id](http://localhost:8000/api/v1/docs#/User/get_user) `e2c834a4-232c-420a-985e-eb5bc59aba24` you should see the user response
   <img width="536" height="288" alt="image" src="https://github.com/user-attachments/assets/826b1588-8e0e-4a5c-a071-a5d8654f7a87" />
