### PR TITLE
fix(deploy): merge release pr triggers release-please action

### DIFF
--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -1,0 +1,47 @@
+# Run this workflow only on merged release-please PRs
+name: Release PR Merged
+on:
+  push:
+    branches: ["main"]
+    # look for the specific files that are changed in a release-pr
+    paths:
+      - CHANGELOG.md
+      - across_server/__init__.py
+      - .release-please-manifest.json
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  deployments: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  ci:
+    # build the container before the release to be able to tag the correctly versioned container.
+    uses: ./.github/workflows/workflow-ci-dockerized-app-build.yml
+    with:
+      organization: "${{ github.event.repository.owner.login }}"
+      repository: "${{ github.event.repository.name }}"
+      image-name: data-ingestion
+      build-args: "BUILD_ENV=deploy"
+    secrets:
+      ecr-region: "${{ secrets.ECR_REGION }}"
+      ecr-iam-role: "${{ secrets.ECR_IAM_ROLE }}"
+      registry: "${{ secrets.ECR_REGISTRY }}"
+      secret-outputs-passphrase: "${{ secrets.GHA_SECRET_OUTPUT_PASSPHRASE }}"
+      ssh-private-key: |
+        ${{ secrets.ACROSS_TOOLS_SSH_KEY }}
+        ${{ secrets.OPENAPI_SDK_SSH_KEY }}
+
+  release-please:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## description

1. Merge to main -> build -> deploy -> generate release PR :white_check_mark:
2. Merge release PR to main -> wasn't triggering merge to main workflow since it was ignoring changed files from release PR. 

Expected, but now need a separate workflow just for release PR merge, this PR adds the workflow.

 - promote will look for a non-existent container by sha of the release PR commit. this will now build push with expected sha, which will be tagged and promoted to staging and prod