### PR TITLE
fix: add title, summary, and description to v1 docs swagger ui

### DIFF
--- a/across_server/core/config.py
+++ b/across_server/core/config.py
@@ -39,6 +39,10 @@ class Config(BaseConfig):
         "data-ingestion/core-server/client_secret"
     )
 
+    APP_TITLE: str = "ACROSS Server"
+    APP_SUMMARY: str = "Astrophysics Cross-Observatory Science Support (ACROSS)"
+    APP_DESCRIPTION: str = "Server providing tools and utilities for various NASA missions to aid in coordination of large observation efforts."
+
     def is_local(self) -> bool:
         return self.RUNTIME_ENV == Environments.LOCAL
 

--- a/across_server/main.py
+++ b/across_server/main.py
@@ -36,7 +36,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 tags_metadata = [
     {
         "name": "v1",
-        "description": "API version 1, check link on the right",
+        "description": "API version 1, click link on the right",
         "externalDocs": {
             "description": "V1 docs",
             "url": f"{config.base_url()}/v1/docs",
@@ -45,9 +45,9 @@ tags_metadata = [
 ]
 
 app = FastAPI(
-    title="ACROSS Server",
-    summary="Astrophysics Cross-Observatory Science Support (ACROSS)",
-    description="Server providing tools and utilities for various NASA missions to aid in coordination of large observation efforts.",
+    title=config.APP_TITLE,
+    summary=config.APP_SUMMARY,
+    description=config.APP_DESCRIPTION,
     root_path=config.ROOT_PATH,
     lifespan=lifespan,
     openapi_tags=tags_metadata,

--- a/across_server/routes/v1/__init__.py
+++ b/across_server/routes/v1/__init__.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from ... import __version__, auth
+from ...core import config
 from . import (
     filter,
     group,
@@ -16,7 +17,12 @@ from . import (
     user,
 )
 
-api = FastAPI(version=__version__)
+api = FastAPI(
+    title=config.APP_TITLE,
+    summary=config.APP_SUMMARY,
+    description=config.APP_DESCRIPTION,
+    version=__version__,
+)
 
 api.include_router(auth.router)
 api.include_router(permission.router)


### PR DESCRIPTION
### Description

The V1 sub-app was missing title, summary and description. 
This PR moves these strings into core config and uses them for both FastAPI apps

### Related Issue(s)

Resolves #361 

### Reviewers
@ACROSS-Team/developers 

### Acceptance Criteria

- The V1 docs swagger ui should display the same title, summary, and description as the root swagger ui

### Testing

- run the server `make dev`
- visit http://localhost:8000/docs
- visit http://localhost:8000/api/v1/docs 
- you should see the same title, summary, and description for both
   <img width="1260" height="635" alt="image" src="https://github.com/user-attachments/assets/ff04d101-6da9-4085-809d-46cb7e219813" />

