### PR TITLE
fix: set local_only_route decorator for debugging routes

### DIFF
--- a/across_server/routes/v1/group/router.py
+++ b/across_server/routes/v1/group/router.py
@@ -3,7 +3,8 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path, Security, status
 
-from ....auth.strategies import global_access, group_access
+from ....auth.strategies import group_access
+from ....util.decorators import local_only_route
 from ..user.service import UserService
 from . import schemas
 from .service import GroupService
@@ -19,20 +20,12 @@ router = APIRouter(
 )
 
 
-@router.get(
-    "/",
+@local_only_route(
+    router,
+    path="/",
+    methods=["GET"],
     summary="Read groups",
-    description="Read many groups.",
-    operation_id="get_groups",
-    status_code=status.HTTP_200_OK,
-    response_model=list[schemas.Group],
-    responses={
-        status.HTTP_200_OK: {
-            "model": list[schemas.Group],
-            "description": "A list of groups",
-        },
-    },
-    dependencies=[Security(global_access, scopes=["group:read"])],
+    description="Read many groups",
 )
 async def get_many(
     service: Annotated[GroupService, Depends(GroupService)],

--- a/across_server/routes/v1/role/router.py
+++ b/across_server/routes/v1/role/router.py
@@ -3,6 +3,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 
+from ....util.decorators import local_only_route
 from . import schemas
 from .service import RoleService
 
@@ -17,19 +18,12 @@ router = APIRouter(
 )
 
 
-@router.get(
-    "/",
+@local_only_route(
+    router,
+    path="/",
+    methods=["GET"],
     summary="Read roles",
-    description="Read many roles.",
-    operation_id="get_roles",
-    status_code=status.HTTP_200_OK,
-    response_model=list[schemas.Role],
-    responses={
-        status.HTTP_200_OK: {
-            "model": list[schemas.Role],
-            "description": "A list of roles",
-        },
-    },
+    description="Read many roles",
 )
 async def get_many(
     service: Annotated[RoleService, Depends(RoleService)],
@@ -38,19 +32,12 @@ async def get_many(
     return [schemas.Role.model_validate(role_model) for role_model in many_role_models]
 
 
-@router.get(
-    "/{role_id}",
+@local_only_route(
+    router,
+    path="/{role_id}",
+    methods=["GET"],
     summary="Read a role",
     description="Read a role by role ID.",
-    operation_id="get_role",
-    status_code=status.HTTP_200_OK,
-    response_model=schemas.Role,
-    responses={
-        status.HTTP_200_OK: {
-            "model": schemas.Role,
-            "description": "The requested role",
-        },
-    },
 )
 async def get(
     service: Annotated[RoleService, Depends(RoleService)], role_id: uuid.UUID

--- a/across_server/routes/v1/user/router.py
+++ b/across_server/routes/v1/user/router.py
@@ -4,9 +4,8 @@ from typing import Annotated
 import structlog
 from fastapi import APIRouter, Depends, status
 
-from across_server.util.decorators import local_only_route
-
 from .... import auth, db
+from ....util.decorators import local_only_route
 from ....util.email.service import EmailService
 from ..group.invite.service import GroupInviteService
 from ..group.service import GroupService
@@ -27,7 +26,13 @@ router = APIRouter(
 )
 
 
-@local_only_route(router, path="/", methods=["GET"])
+@local_only_route(
+    router,
+    path="/",
+    methods=["GET"],
+    summary="Read users",
+    description="Read many users",
+)
 async def get_many(
     service: Annotated[UserService, Depends(UserService)],
 ) -> list[schemas.User]:


### PR DESCRIPTION
### Description

This PR adds the `@local_only_route` decorator for 
`GET /user/` to prevent unauthorized user data enumeration.
`GET /role/` and `GET /role/{role_id}` to prevent confusion, users will only access group roles
`GET /group/` to prevent unauthorized group/user enumeration

### Related Issue(s)

Resolves #363 
Resolves #176 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

`GET /user/` is unavailable in deployed environments
`GET /role/` is unavailable in deployed environments
`GET /role/{role_id}` is unavailable in deployed environments
`GET /group/` is unavailable in deployed environments

### Testing

1. run the server `make dev`
2. visit http://localhost:8000/api/v1/docs#/User/get_many_user__get
3. the route should be present locally
4. label deploy this PR to feat1
5. visit [the deployed environment](https://server.feat1.across.smce.nasa.gov/api/v1/docs) to verify that the route is hidden 
