### PR TITLE
fix: remove unlabeled trigger from feature branch CI workflow

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -2,7 +2,7 @@ name: Feature Branch
 on:
   pull_request:
     branches: [ 'main' ]
-    types: [opened, synchronize, reopened, closed, labeled, unlabeled]
+    types: [opened, synchronize, reopened, closed, labeled]
     paths-ignore:
       # release-pr _should_ be the only PR to ever modify this.
       - across_server/__init__.py


### PR DESCRIPTION
### Description

remove `unlabeled` trigger from feature branch CI workflow

### Related Issue(s)

Resolves #365 

### Reviewers

@nitzan-frock 

### Acceptance Criteria

removing a label doesn't re-trigger CI
