### PR TITLE
fix: nested user service account schema in group role schema causing validation error

### DIFF
--- a/across_server/routes/v1/group/role/schemas.py
+++ b/across_server/routes/v1/group/role/schemas.py
@@ -34,7 +34,7 @@ class ServiceAccount(BaseSchema):
     id: uuid.UUID
     name: str
     description: str | None
-    user: User
+    user: list[User]
 
 
 class GroupRole(GroupRoleRead):


### PR DESCRIPTION
### Description

This PR fixes a schema validation error when a user requests GET /group/{group_id} when a user has a service account with an assigned group role from that group.

### Related Issue(s)

Resolves #367 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

GET /group/{group_id} should not throw and crash when a user has a service account with a group role assigned from that group

### Testing

1. run the server and frontend, it's faster to click buttons than to use the api
2. log in as `sandy@treedome.space` via the frontend
3. open a private browsing window and log in as `dev@nasa.gov` via the frontend
4. as sandy, invite `dev@nasa.gov` to treedome space group
5. as dev, accept the invitation
6. as sandy, assign a group role to dev
7. as dev, open the API and create a service account
8. as dev, assign the role that was assigned by sandy to the service account
9. as sandy, refresh the group management page on the frontend or make a GET /group/{group_id} request for treedome space group
10. you should not see a server crash caused by a validation error! 🎉 