### PR TITLE
feat: add Keck observatory data migration

### DIFF
--- a/tests/routes/v1/tools/visibility_calculator/conftest.py
+++ b/tests/routes/v1/tools/visibility_calculator/conftest.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4

--- a/tests/routes/v1/tools/visibility_calculator/test_visibility_service.py
+++ b/tests/routes/v1/tools/visibility_calculator/test_visibility_service.py
@@ -8,7 +8,6 @@ import pytest
 import across_server.routes.v1.tools.visibility_calculator.service as service_mod
 from across_server.core.enums.visibility_type import VisibilityType
 from across_server.routes.v1.instrument.schemas import Instrument as InstrumentSchema
-from across_server.routes.v1.telescope.exceptions import TelescopeNotFoundException
 from across_server.routes.v1.tools.visibility_calculator.exceptions import (
     VisibilityConstraintsNotFoundException,
     VisibilityTypeNotImplementedException,


### PR DESCRIPTION
### Description

Adds Keck Observatory data as a migration.

The Keck Observatory has two telescopes (Keck I and Keck II), each with different instruments. This PR adds all related observatory/telescope/instrument data. I've also added `AltAzConstraints` for the two telescopes based on documentation, which was tested against Keck's visibility calculator. 

To enable future `Constraints` to be added in data migrations such as this, I updated the `ssa_records.build` function. It now looks for `Constraints` at both the telescope and instrument level. Any defined at the telescope level will be associated with all instruments for that telescope, while those defined at the instrument level will only be associated with that instrument. This simplifies the procedure in instances like Keck, where all instruments on a given telescope share the same constraints. 

Most of the instrument footprints are straightforward, but here's verification for the two tricky ones. DEIMOS serialized footprint vs documentation (check the migration for a comment about the cut-off corners):

<img width="608" height="431" alt="image" src="https://github.com/user-attachments/assets/889ff844-3f68-4968-9ceb-5e1449f9f6f5" />
<img width="792" height="375" alt="image" src="https://github.com/user-attachments/assets/85994dda-a861-4f4e-8cdd-ca7ca15763b6" />

and LRIS serialized vs documentation: 
<img width="603" height="434" alt="image" src="https://github.com/user-attachments/assets/4a9108d9-30ad-49f7-ad71-90bf3a20b35b" />
<img width="348" height="504" alt="image" src="https://github.com/user-attachments/assets/94fe4891-8b26-4b59-80c2-8536a03dcf07" />


### Related Issue(s)

Resolves #331 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. Migrations should upgrade
2. Migrations should downgrade
3. Data looks correct

### Testing

1. `make reset` to run the migrations
2. `alembic downgrade -1` and `alembic upgrade head` to verify that migrations downgrade/upgrade