### PR TITLE
feat: add SAA constraints

### DIFF
--- a/migrations/versions/_2025_11_25_1402-9032acd18e5d_add_saa_constraint.py
+++ b/migrations/versions/_2025_11_25_1402-9032acd18e5d_add_saa_constraint.py
@@ -1,8 +1,8 @@
 """add SAA constraint
 
 Revision ID: 9032acd18e5d
-Revises: d56250541a9b
-Create Date: 2025-10-21 14:02:27.152104
+Revises: 4ee34eaed3a2
+Create Date: 2025-11-25 14:02:27.152104
 
 """
 
@@ -19,7 +19,7 @@ import migrations.versions.model_snapshots.models_2025_10_03 as models
 
 # revision identifiers, used by Alembic.
 revision: str = "9032acd18e5d"
-down_revision: Union[str, None] = "d56250541a9b"
+down_revision: Union[str, None] = "4ee34eaed3a2"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
### Description

Creates `SAAPolygonConstraints` for instruments that do not observe as they pass through the SAA. This will allow for more accurate visibility calculations.

The missions that are in LEO and pass through the SAA include HST, Swift, NICER, NuSTAR, IXPE, and Fermi. Swift SAA constraints were added in a previous PR; this PR adds them for HST, NICER, IXPE, and Fermi. After some research, it seems that NuSTAR will continue to observe even as it goes through the SAA, so I didn't add a constraint for it. Here are the sources for the other instruments' polygon definitions:

 - HST: The [costools](https://github.com/spacetelescope/costools) package has SAA contour definitions for different instruments. These also match the values in several Instrument Science Reports.
 - Fermi: The Fermi [orbit simulator](https://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/orbsim_tutorial.html#SAA) has an SAA polygon definition
 - NICER: The NICER CALDB has SAA polygons
 - IXPE: The [ixpeobssim](https://github.com/lucabaldini/ixpeobssim) package has an SAA definition used for orbit simulation that's the same as Fermi's. A comment in the code says this is an approximation for IXPE, but I haven't been able to find anything better.
 - And [here's](https://heasarc.gsfc.nasa.gov/docs/nustar/nustar_faq.html#saa2) info about NuSTAR's observations during SAA passage

Here's a plot showing all the contours:
<img width="593" height="440" alt="image" src="https://github.com/user-attachments/assets/5af3b1e7-424e-43e7-b8b1-65313d26614b" />

### Related Issue(s)

Resolves #373 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. Migrations should upgrade
2. Migrations should downgrade
3. Visibility calculator route should use the SAA constraint for those instruments

### Testing

1. Run `make reset` and verify migrations run and can upgrade/downgrade
2. Test the visibility calculator with any of the above instruments over a long enough window (~1 day should work) and check that it is using the SAA constraints (you'll have to run the TLE ingestion task locally first)