### PR TITLE
fix(release): release-merge needs ci as dep before publishing

### DIFF
--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -39,6 +39,7 @@ jobs:
 
   release-please:
     runs-on: "ubuntu-latest"
+    needs: [ci]
     steps:
       - uses: googleapis/release-please-action@v4
         with:


### PR DESCRIPTION
## Description

fix(release): release-merge needs ci as dep before publishing

release-please ran concurrently with build and push container step, so publish failed.