### PR TITLE
feat: additional description for visibility calculator route in api docs

### DIFF
--- a/across_server/routes/v1/tools/visibility_calculator/router.py
+++ b/across_server/routes/v1/tools/visibility_calculator/router.py
@@ -27,7 +27,7 @@ router = APIRouter(
     "/windows/{instrument_id}",
     status_code=status.HTTP_200_OK,
     summary="Calculated Visibility Windows",
-    description="Calculate visibility windows of a telescope from a given location.",
+    description="Calculate visibility windows of an instrument for a given observation coordinate \n\n Use GET /telescope/ to retrieve a list of telescopes and their associated instruments \n\n WARNING: This is a long running process and is liable to timeout after a strict 60 second execution limit \n\n If you experience issues retrieving results, please scope your date range to be a smaller window or set `hi_res` to `false`",
     responses={
         status.HTTP_200_OK: {
             "description": "Return visibility window calculation results.",


### PR DESCRIPTION
### Description

This PR adds some supporting documentation to the visibility calculator route.

<img width="1071" height="262" alt="image" src="https://github.com/user-attachments/assets/cbd1fb15-dcf0-434d-a05e-221e8e0535d4" />

### Related Issue(s)

Resolves #382 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. The visibility calculator route should contain the newly added description

### Testing

1. `make dev`
2. [check route documentation](http://localhost:8000/api/v1/docs#/Tools/calculate_windows_tools_visibility_calculator_windows__instrument_id__get)

