### PR TITLE
fix(auth): use correct return type for rotate key

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -163,5 +163,30 @@
                 "head"
             ],
         },
+        {
+            "name": "prod: Start Server",
+            "type": "debugpy",
+            "request": "launch",
+            "envFile": "${workspaceFolder}/.env",
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "pythonArgs": [
+                "-Xfrozen_modules=off"
+            ],
+            "env": {
+                "APP_ENV": "across-plat-ue2-prod",
+                "RUNTIME_ENV": "prod",
+                "ACROSS_DB_USER": "developer",
+                "AWS_PROFILE": "Project-Admin",
+            },
+            "module": "uvicorn",
+            "args": [
+                "across_server.main:app",
+                "--reload",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8000"
+            ]
+        },
     ]
 }

--- a/across_server/routes/v1/system_service_account/router.py
+++ b/across_server/routes/v1/system_service_account/router.py
@@ -52,7 +52,7 @@ async def get(
     status_code=status.HTTP_200_OK,
     responses={
         status.HTTP_200_OK: {
-            "model": schemas.SystemServiceAccount,
+            "model": core.schemas.ServiceAccountSecret,
             "description": "The rotated service account",
         },
     },


### PR DESCRIPTION
### Description
the bug:

```
2026-01-07T22:33:10.723Z
{"err": "AttributeError(\"'SystemServiceAccount' object has no attribute 'secret_key'\")", "event": "Schedule ingestion encountered an unknown error.", "timestamp": "2026-01-07T22:33:10.723665", "logger": "across_data_ingestion.tasks.schedules.jwst.low_fidelity_planned", "level": "error"}
```
the openapi spec uses the incorrect model

this fixes the route to return the correct model for when the openapi spec will attempt to rotate.


### Acceptance Criteria

1. should rotate the key successfully when using the openapi sdk

### Testing

1. we are going to deploy it and see