### PR TITLE
fix(validation): observations endpoint, don't error out on ra/dec = 0, validate range

### DIFF
--- a/across_server/routes/v1/observation/schemas.py
+++ b/across_server/routes/v1/observation/schemas.py
@@ -6,7 +6,7 @@ from typing import Annotated, ClassVar
 
 from across.tools import EnergyBandpass, FrequencyBandpass, WavelengthBandpass
 from across.tools import enums as tools_enums
-from pydantic import BeforeValidator
+from pydantic import BeforeValidator, Field
 
 from ....core.date_utils import convert_to_utc
 from ....core.enums import (
@@ -202,9 +202,9 @@ class ObservationRead(PaginationParams):
         | tools_enums.FrequencyUnit
         | None
     ) = None
-    cone_search_ra: float | None = None
-    cone_search_dec: float | None = None
-    cone_search_radius: float | None = None
+    cone_search_ra: float | None = Field(default=None, ge=0.0, lt=360.0)
+    cone_search_dec: float | None = Field(default=None, ge=-90.0, le=90.0)
+    cone_search_radius: float | None = Field(default=None, gt=0.0)
     type: ObservationType | None = None
     depth_value: float | None = None
     depth_unit: DepthUnit | None = None

--- a/across_server/routes/v1/observation/service.py
+++ b/across_server/routes/v1/observation/service.py
@@ -138,12 +138,14 @@ class ObservationService:
             )
 
         bandpass_params = [data.bandpass_min, data.bandpass_max, data.bandpass_type]
-        if any(bandpass_params) and not all(bandpass_params):
+        if any(param is not None for param in bandpass_params) and not all(
+            param is not None for param in bandpass_params
+        ):
             raise InvalidObservationReadParametersException(
                 message="Bandpass parameters are not complete. Please provide all bandpass parameters."
             )
 
-        elif all(bandpass_params):
+        elif all(param is not None for param in bandpass_params):
             try:
                 if data.bandpass_type in tools_enums.WavelengthUnit:
                     wavelength_bandpass = WavelengthBandpass(
@@ -185,11 +187,13 @@ class ObservationService:
             data.cone_search_dec,
             data.cone_search_radius,
         ]
-        if any(cone_search_params) and not all(cone_search_params):
+        if any(param is not None for param in cone_search_params) and not all(
+            param is not None for param in cone_search_params
+        ):
             raise InvalidObservationReadParametersException(
                 message="Cone search parameters are not complete. Please provide all cone search parameters."
             )
-        elif all(cone_search_params):
+        elif all(param is not None for param in cone_search_params):
             cone_search_point = from_shape(
                 Point(data.cone_search_ra, data.cone_search_dec),  # type: ignore
                 srid=4326,


### PR DESCRIPTION
## Title

fix(validation): don't error out on ra/dec = 0, validate range

### Description

This PR fixes two bugs:

1. in `/observations` endpoint `cone_search_ra` or `cone_search_dec` being set to zero is considered invalid.
2. `cone_search_ra` and `cone_search_dec` do not have range validation.
3. Also fixes issue if any bandpass value is zero, a rarer case but still possible.

### Related Issue(s)

Resolves #461 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

`/observations` endpoint accepts RA/Dec values of 0, but not a invalid numerical values like RA=-2 or +361.

### Testing

1. Running locally this URL returns a result: http://localhost:8000/api/v1/observation/?cone_search_ra=0&cone_search_dec=0&cone_search_radius=180
2. Running locally this URL returns a validation error: http://localhost:8000/api/v1/observation/?cone_search_ra=361&cone_search_dec=0&cone_search_radius=180
4. Other invalid combos in SwaggerUI fail.
