### PR TITLE
fix(docs): edit server configuration to enable proxy usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,4 @@ EXPOSE 8000
 RUN useradd -m -u 5678 appuser && chown -R appuser /app
 USER appuser
 
-CMD ["uvicorn", "across_server.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "across_server.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "54.146.107.154"]

--- a/across_server/core/config.py
+++ b/across_server/core/config.py
@@ -15,7 +15,7 @@ class Config(BaseConfig):
     HOST: str = "http://localhost"
     FRONTEND_HOST: str = "http://localhost:5173"
     PORT: int = 8000
-    ROOT_PATH: str = "/api"
+    ROOT_PATH: str = "/data-sites/across/app/api"
 
     SERVICE_ACCOUNT_EXPIRATION_DURATION: int = 30
 

--- a/across_server/core/config.py
+++ b/across_server/core/config.py
@@ -15,7 +15,7 @@ class Config(BaseConfig):
     HOST: str = "http://localhost"
     FRONTEND_HOST: str = "http://localhost:5173"
     PORT: int = 8000
-    ROOT_PATH: str = "/data-sites/across/app/api"
+    ROOT_PATH: str = "/api"
 
     SERVICE_ACCOUNT_EXPIRATION_DURATION: int = 30
 


### PR DESCRIPTION
### Description

Attempting to debug the docs not loading form the proxy call

### Related Issue(s)

Resolves #467 

### Acceptance Criteria

proxy works to load the docs 

### Testing

go to the docs page https://science-dev.data.nasa.gov/data-sites/across/app/api/v1/docs and it should load correctly
