### PR TITLE
fix(data): change fermi lat observation types to slew

### DIFF
--- a/migrations/versions/_2026_02_18_1559-7774f10e57fb_fix_fermi_observation_types.py
+++ b/migrations/versions/_2026_02_18_1559-7774f10e57fb_fix_fermi_observation_types.py
@@ -1,7 +1,7 @@
 """fix fermi observation types
 
 Revision ID: 7774f10e57fb
-Revises: effbd9073baa
+Revises: 59e4b9fd7386
 Create Date: 2026-02-18 15:59:54.013426
 
 """
@@ -16,7 +16,7 @@ from across_server.core.enums import ObservationType
 
 # revision identifiers, used by Alembic.
 revision: str = "7774f10e57fb"
-down_revision: Union[str, None] = "effbd9073baa"
+down_revision: Union[str, None] = "59e4b9fd7386"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
### Description

This PR adds a migration to change the `type` of all observations for Fermi LAT from `imaging` to `slew`. Fermi LAT is a slew survey mission, so this corrects the erroneous observation data.

### Related Issue(s)

Resolves #483 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. Migrations should upgrade and downgrade
2. `Observation.type` for existing Fermi LAT observations should change to `slew`

### Testing

1. I ingested a copy of the production database (>200k observations)
2. Ran `alembic upgrade head` and verified the Fermi LAT observation types were changed successfully (this took 3 seconds or less)