### PR TITLE
feat(login): only send magic_link to webserver when running locally for development

### DIFF
--- a/tests/routes/v1/auth/router_test.py
+++ b/tests/routes/v1/auth/router_test.py
@@ -22,6 +22,28 @@ class TestLoginRoute:
         assert res.status_code == fastapi.status.HTTP_200_OK
 
     @pytest.mark.asyncio
+    async def test_should_return_magic_link_dict_when_local(
+        self, mock_config_runtime_env_is_local: AsyncMock
+    ) -> None:
+        """Should return a dict containing magic_link when successful"""
+        mock_config_runtime_env_is_local.return_value = True
+        res = await self.client.post(self.endpoint)
+        response_dict = res.json()
+
+        assert isinstance(response_dict, dict)
+
+    @pytest.mark.asyncio
+    async def test_magic_link_dict_should_contain_string(
+        self, mock_config_runtime_env_is_local: AsyncMock
+    ) -> None:
+        """Should return a dict containing magic_link when successful"""
+        mock_config_runtime_env_is_local.return_value = True
+        res = await self.client.post(self.endpoint)
+        response_dict = res.json()
+
+        assert isinstance(response_dict["magic_link"], str)
+
+    @pytest.mark.asyncio
     async def test_should_call_magic_link_generate(
         self,
         mock_magic_link_generate: AsyncMock,

--- a/tests/routes/v1/user/router_test.py
+++ b/tests/routes/v1/user/router_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import fastapi
@@ -83,3 +83,25 @@ class TestUserPostRoute:
         with patch("across_server.routes.v1.user.router.logger") as log_mock:
             await self.client.post(self.endpoint, json=self.data)
             assert "Email service failed" in log_mock.error.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_should_return_magic_link_dict_when_local(
+        self, mock_config_runtime_env_is_local: AsyncMock
+    ) -> None:
+        """Should return a dict when local"""
+        mock_config_runtime_env_is_local.return_value = True
+        res = await self.client.post(self.endpoint, json=self.data)
+        response_dict = res.json()
+
+        assert isinstance(response_dict, dict)
+
+    @pytest.mark.asyncio
+    async def test_should_contain_magic_link_string(
+        self, mock_config_runtime_env_is_local: AsyncMock
+    ) -> None:
+        """Should return a dict containing magic_link string when local"""
+        mock_config_runtime_env_is_local.return_value = True
+        res = await self.client.post(self.endpoint, json=self.data)
+        response_dict = res.json()
+
+        assert isinstance(response_dict["magic_link"], str)


### PR DESCRIPTION
### Description

Motivation: the magic_link can be used in the frontend webserver to automatically redirect when running locally bypassing  the email step entirely for developer convenience and improved testing flow.

The server now only sends the magic_link as part of the response to POST /login and POST /user for local development.

### Related Issue(s)

Resolves #482 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. When running locally for development, POST /login and POST /user routes return the magic_link as part of the response to the webserver

### Testing

1. Pull this PR and the accompanying frontend PR, run both + db
2. [follow instructions on frontend PR](https://github.com/NASA-ACROSS/across-frontend/pull/247)
3. check that unit tests accomplish their goal and pass