### PR TITLE
fix(deprecation): update deprecated 422 constant

### DIFF
--- a/across_server/core/exceptions.py
+++ b/across_server/core/exceptions.py
@@ -41,7 +41,7 @@ class NotFoundException(AcrossHTTPException):
 class RequiredFieldException(AcrossHTTPException):
     def __init__(self, entity: str, field: str, message: str | None) -> None:
         super().__init__(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             message=message if message else f"{entity}.{field} is required.",
             log_data={
                 "entity": f"{entity}.{field}",
@@ -53,7 +53,7 @@ class RequiredFieldException(AcrossHTTPException):
 class InvalidEntityException(AcrossHTTPException):
     def __init__(self, entity_name: str, message: str):
         super().__init__(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             message=f"Invalid {entity_name}: {message}",
             log_data={
                 f"{entity_name}": message,

--- a/across_server/routes/v1/schedule/exceptions.py
+++ b/across_server/routes/v1/schedule/exceptions.py
@@ -22,7 +22,7 @@ class DuplicateScheduleException(AcrossHTTPException):
 class ScheduleInstrumentNotFoundException(AcrossHTTPException):
     def __init__(self, instrument_id: uuid.UUID, telescope_id: uuid.UUID):
         super().__init__(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             message=f" Instrument ({instrument_id}) not found for telescope ({telescope_id}).",
             log_data={"entity": "Schedule", "instrument_id": instrument_id},
         )

--- a/across_server/routes/v1/schedule/router.py
+++ b/across_server/routes/v1/schedule/router.py
@@ -158,7 +158,7 @@ async def create(
             "model": ListResponse[uuid.UUID],
             "description": "Created schedule ids",
         },
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {
             "description": "Incorrect schedule parameters"
         },
     },

--- a/across_server/routes/v1/user/schemas.py
+++ b/across_server/routes/v1/user/schemas.py
@@ -18,7 +18,7 @@ def validate_no_html(value: str) -> str:
     """Ensure the string contains no HTML tags or other special characters."""
     if HTML_TAG_REGEX.search(value):
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid format."
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Invalid format."
         )
     return value
 

--- a/tests/routes/v1/schedule/router_test.py
+++ b/tests/routes/v1/schedule/router_test.py
@@ -47,7 +47,7 @@ class TestScheduleRouter:
             self.post_data.pop(required_fields)
             res = await self.client.post(self.endpoint, json=self.post_data)
 
-            assert res.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY
+            assert res.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT
 
     class TestGet(Setup):
         @pytest.mark.asyncio
@@ -137,7 +137,7 @@ class TestScheduleRouter:
                 self.endpoint + "bulk", json=self.post_many_data
             )
 
-            assert res.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY
+            assert res.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT
 
         @pytest.mark.asyncio
         async def test_should_return_422_when_provided_multiple_telescope_ids(
@@ -152,4 +152,4 @@ class TestScheduleRouter:
                 self.endpoint + "bulk", json=self.post_many_data
             )
 
-            assert res.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY
+            assert res.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/tests/routes/v1/service_account/router_test.py
+++ b/tests/routes/v1/service_account/router_test.py
@@ -47,7 +47,7 @@ class TestServiceAccountRouter:
             data.pop("name")
             res = await self.client.post(self.endpoint, json=self.post_data)
 
-            assert res.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY
+            assert res.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT
 
     class TestGet(Setup):
         @pytest.mark.asyncio

--- a/tests/routes/v1/tools/visibility_calculator/router_test.py
+++ b/tests/routes/v1/tools/visibility_calculator/router_test.py
@@ -125,4 +125,4 @@ class TestJointVisibilityCalculatorRouter:
             self.endpoint,
             params=fake_joint_visibility_read_params,
         )
-        assert res.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert res.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT


### PR DESCRIPTION
## Title

fix(deprecation): update deprecated 422 constant

### Description

FastAPI's `status` module has deprecated `HTTP_422_UNPROCESSABLE_ENTITY` in favor of `HTTP_422_UNPROCESSABLE_CONTENT`. This PR updates to the non-deprecated value, in order to remove warnings generated by using the deprecated value.

### Related Issue(s)

Resolves #507 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

No more deprecation warnings.

### Testing

Run `make test` and witness no warnings.
