### PR TITLE
fix(db): fix multiple head revisions

### DIFF
--- a/migrations/versions/_2026_02_24_1607-ce236d6cd364_resolve_ix_naming.py
+++ b/migrations/versions/_2026_02_24_1607-ce236d6cd364_resolve_ix_naming.py
@@ -1,7 +1,7 @@
 """resolve ix naming
 
 Revision ID: ce236d6cd364
-Revises: 00b3a6244b1c
+Revises: 90c0b855ecde
 Create Date: 2026-02-24 16:07:18.255481
 
 """
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "ce236d6cd364"
-down_revision: Union[str, None] = "00b3a6244b1c"
+down_revision: Union[str, None] = "90c0b855ecde"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/migrations/versions/_2026_03_02_1207-21f7b6d5cd1d_add_missing_schedule_cadences.py
+++ b/migrations/versions/_2026_03_02_1207-21f7b6d5cd1d_add_missing_schedule_cadences.py
@@ -1,7 +1,7 @@
 """add missing schedule cadences
 
 Revision ID: 21f7b6d5cd1d
-Revises: 90c0b855ecde
+Revises: ce236d6cd364
 Create Date: 2026-03-02 12:07:55.276903
 
 """
@@ -53,7 +53,7 @@ CADENCES = [
 
 # revision identifiers, used by Alembic.
 revision: str = "21f7b6d5cd1d"
-down_revision: Union[str, None] = "90c0b855ecde"
+down_revision: Union[str, None] = "ce236d6cd364"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
### Description

Fixes the migration order so that alembic can run migrations. Previously multiple head revisions were present after a PR merge.

### Related Issue(s)

Resolves #520

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. Migrations upgrade and downgrade

### Testing

1. Run `make reset` and verify it works