### PR TITLE
fix(telescope): hydrate null instrument values in /telescope endpoint

### DIFF
--- a/across_server/routes/v1/telescope/schemas.py
+++ b/across_server/routes/v1/telescope/schemas.py
@@ -10,7 +10,7 @@ from ....db.models import Instrument as InstrumentModel
 from ....db.models import Telescope as TelescopeModel
 from ..filter.schemas import Filter
 from ..footprint.schemas import Footprint
-from ..instrument.schemas import InstrumentBase
+from ..instrument.schemas import ConstraintsAdaptor, InstrumentBase
 
 
 class TelescopeBase(BaseSchema):
@@ -165,6 +165,11 @@ class TelescopeInstrument(InstrumentBase):
             else [],
             filters=filters if include_filters else [],
             created_on=obj.created_on,
+            constraints=ConstraintsAdaptor.validate_python(
+                [constraint.constraint_parameters for constraint in obj.constraints]
+            ),
+            visibility_type=obj.visibility_type,
+            observation_strategy=obj.observation_strategy,
         )
 
 


### PR DESCRIPTION
## Title

fix(telescope): hydrate null instrument values in /telescope endpoint

### Description

This PR fixes a bug where instrument values `constraints`, `visibility_type` and `observation_strategy` are not hydrated in in the `instruments` section returned by the `/telescope` endpoint.

### Related Issue(s)

Resolves #523 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

If this is the intended functionality.

### Testing

Tested using https://github.com/NASA-ACROSS/across-frontend/pull/267 which without this PR does not hydrate constraint information for missions. Also you can go direct to SwaggerUI to check.
