### PR TITLE
fix(hotfix): configure astropy to not download files

### DIFF
--- a/across_server/main.py
+++ b/across_server/main.py
@@ -22,6 +22,7 @@ from .routes import v1
 
 # Disable auto-downloading of IERS data
 iers.conf.auto_download = False
+iers.conf.auto_max_age = None
 
 # Configure UTC system time
 os.environ["TZ"] = "UTC"


### PR DESCRIPTION
## Title

fix(hotfix): configure astropy to not download files

### Description

Fixes crash on `feat1` when trying to calculate JWST visibility due to astropy attempting to download a file that is not required.

### Related Issue(s)

Resolves #527 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

No file downloads occur when running server due to `JPLEphemeris` usage.

### Testing

1. Start up across-server
2. Remove your ~/.astropy directory to clear out existing downloaded files.
3. Go to this URL: http://localhost:8000/api/v1/tools/visibility-calculator/windows/1e1b0263-7e49-4c00-985a-568927353700?ra=266&dec=-29&date_range_begin=2026-03-24&date_range_end=2026-03-25&hi_res=true&min_visibility_duration=0
4. Check logs for signs of downloaded file, you shouldn't find anything.
5. Check out `main` branch and try the above again.
6. Witness files being downloaded.
