### PR TITLE
fix(api): stop across-tools custom types leaking into openapi.json

### DIFF
--- a/across_server/core/date_utils.py
+++ b/across_server/core/date_utils.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Annotated
 
-from astropy.time import Time
+from astropy.time import Time  # type: ignore[import-untyped]
 from pydantic import BeforeValidator
 
 

--- a/across_server/core/date_utils.py
+++ b/across_server/core/date_utils.py
@@ -24,7 +24,7 @@ def convert_to_utc(date: str | datetime) -> datetime:
             return date.astimezone(timezone.utc).replace(tzinfo=None)
         else:
             return date
-    elif isinstance(date, Time):
+    elif isinstance(date, Time) and date.isscalar:
         return date.datetime
     else:
         raise ValueError("Date must be a string or datetime")

--- a/across_server/core/date_utils.py
+++ b/across_server/core/date_utils.py
@@ -5,7 +5,7 @@ from astropy.time import Time  # type: ignore[import-untyped]
 from pydantic import BeforeValidator
 
 
-def convert_to_utc(date: str | datetime) -> datetime:
+def convert_to_utc(date: str | datetime | Time) -> datetime:
     """
     Converts datetimes or strings to UTC and remove timezone info
     Timezone-naive datetimes are needed for sqlalchemy

--- a/across_server/core/date_utils.py
+++ b/across_server/core/date_utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from typing import Annotated
 
+from astropy.time import Time
 from pydantic import BeforeValidator
 
 
@@ -23,6 +24,8 @@ def convert_to_utc(date: str | datetime) -> datetime:
             return date.astimezone(timezone.utc).replace(tzinfo=None)
         else:
             return date
+    elif isinstance(date, Time):
+        return date.datetime
     else:
         raise ValueError("Date must be a string or datetime")
 

--- a/across_server/routes/v1/tools/visibility_calculator/schemas.py
+++ b/across_server/routes/v1/tools/visibility_calculator/schemas.py
@@ -1,7 +1,6 @@
 from uuid import UUID
 
 from across.tools.core.enums import ConstraintType
-from across.tools.core.schemas import AstropyDateTime
 from pydantic import ConfigDict, Field
 
 from .....core.date_utils import UTCDatetime
@@ -15,7 +14,7 @@ class ConstrainedDate(BaseSchema):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    datetime: AstropyDateTime
+    datetime: UTCDatetime
     constraint: ConstraintType
     observatory_id: UUID
 

--- a/tests/core/date_utils_test.py
+++ b/tests/core/date_utils_test.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from astropy.time import Time
+from astropy.time import Time  # type: ignore[import-untyped]
 from dateutil import tz  # type: ignore[import]
 
 from across_server.core.date_utils import convert_to_utc

--- a/tests/core/date_utils_test.py
+++ b/tests/core/date_utils_test.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from astropy.time import Time
 from dateutil import tz  # type: ignore[import]
 
 from across_server.core.date_utils import convert_to_utc
@@ -61,7 +62,24 @@ class TestConvertToUTC:
         """Should convert non-UTC strings to UTC before removing timezone"""
         assert convert_to_utc(self.mock_date_string_gsfc) == self.mock_datetime_tz_naive
 
+    def test_should_handle_scalar_astropy_time(self) -> None:
+        """Should convert scalar astropy Time values to timezone-naive datetimes"""
+        astropy_time = Time("2025-01-01T00:00:00", format="isot", scale="utc")
+
+        assert convert_to_utc(astropy_time) == self.mock_datetime_tz_naive
+
     def test_should_raise_exception_when_input_not_date(self) -> None:
         """should raise an exception when input is not a datetime or iso format string"""
         with pytest.raises(ValueError):
             convert_to_utc("twenty twenty four")
+
+    def test_should_raise_exception_when_astropy_time_is_not_scalar(self) -> None:
+        """Should reject non-scalar astropy Time values"""
+        astropy_time = Time(
+            ["2025-01-01T00:00:00", "2025-01-02T00:00:00"],
+            format="isot",
+            scale="utc",
+        )
+
+        with pytest.raises(ValueError, match="Date must be a string or datetime"):
+            convert_to_utc(astropy_time)


### PR DESCRIPTION
## Title

fix(api): stop across-tools custom types leaking into openapi.json

### Description

Removes `AstropyDateTime` from `schema.py` to stop it leaking into `openapi.json`.

### Related Issue(s)

Resolves #550 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

`/visibility` routes should work. Auto-generated client should not create weird `Datetime` model.

### Testing

Tested with swagger ui. Download openapi.json to `across-server-openapi-python`, and type `make`. Check `across/sdk/v1/models/constrained_date.py` and see that it now has `datetime: datetime` in it, rather than `datetime: Datetime` where `Datetime` is a custom model. 

`across/sdk/v1/models/datetime.py` will also now not be regenerated if deleted before `make`.
