### PR TITLE
fix(auth): 401 auth error code for mismatch creds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,6 +68,5 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "makefile.configureOnOpen": false,
-    "python-envs.pythonProjects": []
+    "makefile.configureOnOpen": false
 }

--- a/across_server/auth/service.py
+++ b/across_server/auth/service.py
@@ -84,7 +84,7 @@ class AuthService:
             argon2.exceptions.InvalidHashError,
         ):
             raise AcrossHTTPException(
-                400,
+                401,
                 "invalid_grant",
                 {
                     "reason": "Invalid password for user.",


### PR DESCRIPTION
### Description

return the appropriate error code, allows the user (frontend) to have clearer error handling.

### Acceptance Criteria

should return 401 when the credentials cannot be authenticated.

### Testing

1. run the server
2. goto http://localhost:8000/api/v1/docs
3. click the "authorize" button and add `a13bbcdd-798d-43cd-bb2a-6b10347db2a3` as the username (client_id) and some garbage for the password (client_secret)
4. try out POST `auth/token`
5. should see 401
6. also try it without any authorization (logout) and should also see 401

```
2026-04-09T20:34:05.892828 [info     ] 127.0.0.1:63217 - "POST /api/v1/auth/token HTTP/1.1" 401 [across_server.core.middleware.logging] duration=129462333 http={'url': 'http://localhost:8000/api/v1/auth/token', 'status_code': 401, 'method': 'POST', 'version': '1.1'} network={'client': {'ip': '127.0.0.1', 'port': 63217}} request_id=7a01b42046ec41dd812f0cf28c2a76e8
```

<img width="507" height="165" alt="image" src="https://github.com/user-attachments/assets/22b71305-2226-447d-bca1-bd1aa7a3a7b2" />

