### PR TITLE
feat: add group to group role read schema, rename snake case routes to kebab case

### DIFF
--- a/across_server/routes/v1/group/role/schemas.py
+++ b/across_server/routes/v1/group/role/schemas.py
@@ -9,8 +9,19 @@ class GroupRoleBase(BaseSchema):
     permissions: list[Permission]
 
 
+# This is explicitly defined due to
+#   A) parent data should define what data from the child it needs
+#   B) pydantic does not handle circular imports, so even if we
+#      wanted to import the related schema, we can't use it.
+class Group(BaseSchema):
+    id: uuid.UUID
+    name: str
+    short_name: str
+
+
 class GroupRoleRead(GroupRoleBase):
     id: uuid.UUID
+    group: Group
 
 
 class GroupRoleCreate(BaseSchema):

--- a/across_server/routes/v1/system_service_account/router.py
+++ b/across_server/routes/v1/system_service_account/router.py
@@ -45,7 +45,7 @@ async def get(
 
 
 @router.patch(
-    "/{service_account_id}/rotate_key",
+    "/{service_account_id}/rotate-key",
     summary="Rotate a service account key",
     description="Rotate service account key and reset expiration based on expiration duration",
     operation_id="service_account_rotate_key",

--- a/across_server/routes/v1/user/schemas.py
+++ b/across_server/routes/v1/user/schemas.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, BeforeValidator, EmailStr
 
 from ....core.schemas import Permission
 from ....core.schemas.base import BaseSchema
+from ..group.schemas import GroupBase
 from ..role.schemas import RoleBase
 
 # Regular expression to detect HTML tags
@@ -58,6 +59,7 @@ class GroupRole(BaseSchema):
     id: uuid.UUID
     name: str
     permissions: list[Permission]
+    group: GroupBase
 
 
 class Group(BaseSchema):

--- a/across_server/routes/v1/user/service_account/router.py
+++ b/across_server/routes/v1/user/service_account/router.py
@@ -8,7 +8,7 @@ from . import schemas
 from .service import ServiceAccountService
 
 router = APIRouter(
-    prefix="/user/{user_id}/service_account",
+    prefix="/user/{user_id}/service-account",
     tags=["ServiceAccount"],
     responses={
         status.HTTP_404_NOT_FOUND: {
@@ -119,7 +119,7 @@ async def delete(
 
 
 @router.patch(
-    "/{service_account_id}/rotate_key",
+    "/{service_account_id}/rotate-key",
     summary="Rotate a service account key",
     description="Rotate service account key and reset expiration based on expiration_duration",
     operation_id="user_service_account_rotate_key",

--- a/tests/routes/v1/conftest.py
+++ b/tests/routes/v1/conftest.py
@@ -84,12 +84,26 @@ def fake_user(
 
 
 @pytest.fixture
-def fake_group_role(fake_permissions: list[models.Permission]) -> models.GroupRole:
+def fake_group_role_base() -> models.Group:
+    return models.Group(
+        **{
+            "id": "12aa89d2-1b77-4a34-9504-063236b58782",
+            "name": "test group",
+            "short_name": "test",
+        }
+    )
+
+
+@pytest.fixture
+def fake_group_role(
+    fake_permissions: list[models.Permission], fake_group_role_base: models.Group
+) -> models.GroupRole:
     return models.GroupRole(
         **{
             "id": "12aa89d2-1b77-4a34-9504-063236b58782",
             "name": "Schedule Operations",
             "permissions": fake_permissions,
+            "group": fake_group_role_base,
         }
     )
 

--- a/tests/routes/v1/service_account/router_test.py
+++ b/tests/routes/v1/service_account/router_test.py
@@ -13,7 +13,7 @@ class Setup:
     async def setup(self, async_client: AsyncClient) -> None:
         user_id = uuid.uuid4()
         self.client = async_client
-        self.endpoint = f"/user/{user_id}/service_account/"
+        self.endpoint = f"/user/{user_id}/service-account/"
         self.post_data = {
             "name": "service account name",
             "description": "test service account description",


### PR DESCRIPTION
### Description

- adds `group` info to `GroupRoleRead` schema which makes it possible to know which group each group_role belongs to when retrieving User information and parsing group_roles on `User` and `ServiceAccount`
- renames snake case routes `service_account` to kebab case `service-account` for consistency

### Related Issue(s)

Resolves #560 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. The sdk should not require any changes to support new route names since the SDK uses operation_id
2. [Frontend service account UI PR](https://github.com/NASA-ACROSS/across-frontend/pull/301) works as expected using this PR

### Testing
1. pull the PR and run the server `make dev`
2. [follow instructions on frontend PR](https://github.com/NASA-ACROSS/across-frontend/pull/301)
