### PR TITLE
feat: add spherex data migration

### DIFF
--- a/across_server/core/enums/instrument_type.py
+++ b/across_server/core/enums/instrument_type.py
@@ -11,3 +11,4 @@ class InstrumentType(str, Enum):
     XRAY_COUNTING_SPECTROMETER = "xray_counting_spectrometer"
     CODED_APERTURE_IMAGER = "coded_aperture_imager"
     XRAY_IMAGING_SPECTROMETER = "xray_imaging_spectrometer"
+    IMAGING_SPECTROMETER = "imaging_spectrometer"

--- a/migrations/versions/_2026_04_21_1447-58b4ec651f87_add_spherex_observatory_data.py
+++ b/migrations/versions/_2026_04_21_1447-58b4ec651f87_add_spherex_observatory_data.py
@@ -1,0 +1,231 @@
+"""add spherex observatory data
+
+Revision ID: 58b4ec651f87
+Revises: a99c9ee52dce
+Create Date: 2026-04-21 14:47:22.948075
+
+"""
+
+import uuid
+from typing import Sequence, Union
+
+from across.tools import WavelengthBandpass
+from across.tools import enums as tools_enums
+from across.tools.core.enums import ConstraintType
+from across.tools.visibility.constraints import (
+    EarthLimbConstraint,
+    MoonAngleConstraint,
+    SunAngleConstraint,
+)
+from alembic import op
+from sqlalchemy import orm
+
+import migrations.versions.model_snapshots.models_2026_04_21 as snapshot_models
+from across_server.core.enums import EphemerisType, InstrumentFOV, InstrumentType
+from across_server.core.enums.observation_strategy import ObservationStrategy
+from across_server.core.enums.observatory_type import ObservatoryType
+from across_server.core.enums.visibility_type import VisibilityType
+from migrations.build_records import ssa_records
+from migrations.util.footprint_util import rectangle_footprint
+
+# revision identifiers, used by Alembic.
+revision: str = "58b4ec651f87"
+down_revision: Union[str, None] = "a99c9ee52dce"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+"""
+SPHEREx is an imaging spectrometer that is conducting a near-infrared spectral survey
+of the entire sky. It has a rectangular 3.5 x 11.5 deg FOV.
+
+SPHEREx is unique in that each detector has a spatially-varying central wavelength.
+What that means is that where an object is on the detector dictates what wavelength
+it is observed in. In other words, each bandpass effectively acts as a mini grism
+with 17 resolution elements. Therefore, a given observation will not cover the full
+wavelength range of a bandpass for each coordinate in the field of view. However,
+for our purposes we can just define the below relatively broad bandpasses.
+
+SPHEREx must maintain pointings > 93.5 degrees from the sun, > 32 degrees from the moon,
+and cannot point > 45 degrees from local zenith (equivalent to < 135 degrees from the Earth limb).
+
+More information about SPHEREx's design, bandpasses, and constraints can be found in these papers:
+ - https://ui.adsabs.harvard.edu/abs/2026ApJ...999..139B/abstract
+ - https://ui.adsabs.harvard.edu/abs/2020SPIE11443E..0IC/abstract
+"""
+SPHEREX_FOOTPRINT = rectangle_footprint(width_deg=3.5, height_deg=11.5)
+
+SPHEREX_BAND_1 = WavelengthBandpass(
+    filter_name="SPHEREx Band 1",
+    min=0.75,
+    max=1.11,
+    unit=tools_enums.WavelengthUnit.MICRON,
+)
+SPHEREX_BAND_2 = WavelengthBandpass(
+    filter_name="SPHEREx Band 2",
+    min=1.11,
+    max=1.64,
+    unit=tools_enums.WavelengthUnit.MICRON,
+)
+SPHEREX_BAND_3 = WavelengthBandpass(
+    filter_name="SPHEREx Band 3",
+    min=1.64,
+    max=2.42,
+    unit=tools_enums.WavelengthUnit.MICRON,
+)
+SPHEREX_BAND_4 = WavelengthBandpass(
+    filter_name="SPHEREx Band 4",
+    min=2.42,
+    max=3.82,
+    unit=tools_enums.WavelengthUnit.MICRON,
+)
+SPHEREX_BAND_5 = WavelengthBandpass(
+    filter_name="SPHEREx Band 1=5",
+    min=3.82,
+    max=4.42,
+    unit=tools_enums.WavelengthUnit.MICRON,
+)
+SPHEREX_BAND_6 = WavelengthBandpass(
+    filter_name="SPHEREx Band 6",
+    min=4.42,
+    max=5.00,
+    unit=tools_enums.WavelengthUnit.MICRON,
+)
+
+
+OBSERVATORY: dict = {
+    "id": uuid.UUID("8af7c8c9-3362-430a-8156-0d1e38808098"),
+    "name": "Spectro-Photometer for the History of the Universe, Epoch of Reionization, and Ices Explorer",
+    "short_name": "SPHEREx",
+    "type": ObservatoryType.SPACE_BASED.value,
+    "reference_url": "https://spherex.caltech.edu",
+    "telescopes": [
+        {
+            "id": uuid.UUID("0c8163cd-aff1-445e-9dc2-ec396aab0340"),
+            "name": "Spectro-Photometer for the History of the Universe, Epoch of Reionization, and Ices Explorer",
+            "short_name": "SPHEREx",
+            "is_operational": True,
+            "reference_url": "https://spherex.caltech.edu",
+            "instruments": [
+                {
+                    "id": uuid.UUID("fbe30ef9-bb88-454d-81a8-01cdc043a1d2"),
+                    "name": "Spectro-Photometer for the History of the Universe, Epoch of Reionization, and Ices Explorer",
+                    "short_name": "SPHEREx",
+                    "type": InstrumentType.IMAGING_SPECTROMETER.value,
+                    "field_of_view": InstrumentFOV.POLYGON.value,
+                    "footprint": SPHEREX_FOOTPRINT,
+                    "reference_url": "https://spherex.caltech.edu/page/instrument",
+                    "visibility_type": VisibilityType.EPHEMERIS.value,
+                    "observation_strategy": ObservationStrategy.SURVEY.value,
+                    "filters": [
+                        {
+                            "id": uuid.UUID("71afe5a7-675e-4342-bb7c-3531e67d5778"),
+                            "name": "SPHEREx Band 1",
+                            "min_wavelength": SPHEREX_BAND_1.min,
+                            "max_wavelength": SPHEREX_BAND_1.max,
+                            "is_operational": True,
+                        },
+                        {
+                            "id": uuid.UUID("b87bb481-572c-4648-9822-66020e150f75"),
+                            "name": "SPHEREx Band 2",
+                            "min_wavelength": SPHEREX_BAND_2.min,
+                            "max_wavelength": SPHEREX_BAND_2.max,
+                            "is_operational": True,
+                        },
+                        {
+                            "id": uuid.UUID("5fad0293-e05f-4f8f-b8a5-1078cbe9eb61"),
+                            "name": "SPHEREx Band 3",
+                            "min_wavelength": SPHEREX_BAND_3.min,
+                            "max_wavelength": SPHEREX_BAND_3.max,
+                            "is_operational": True,
+                        },
+                        {
+                            "id": uuid.UUID("303bca68-4b46-4c6e-a166-1fc68772bf5c"),
+                            "name": "SPHEREx Band 4",
+                            "min_wavelength": SPHEREX_BAND_4.min,
+                            "max_wavelength": SPHEREX_BAND_4.max,
+                            "is_operational": True,
+                        },
+                        {
+                            "id": uuid.UUID("7e395b0e-a51e-448c-ad0d-becee5a151e5"),
+                            "name": "SPHEREx Band 5",
+                            "min_wavelength": SPHEREX_BAND_5.min,
+                            "max_wavelength": SPHEREX_BAND_5.max,
+                            "is_operational": True,
+                        },
+                        {
+                            "id": uuid.UUID("dbd210bb-b2d2-48a5-84c3-edcee3ebf657"),
+                            "name": "SPHEREx Band 6",
+                            "min_wavelength": SPHEREX_BAND_6.min,
+                            "max_wavelength": SPHEREX_BAND_6.max,
+                            "is_operational": True,
+                        },
+                    ],
+                },
+            ],
+            "constraints": [
+                {
+                    "id": uuid.UUID("de4b2fbb-93e9-4074-845a-336964de0820"),
+                    "constraint_type": ConstraintType.EARTH,
+                    "constraint_parameters": EarthLimbConstraint(
+                        min_angle=135.0,
+                    ).model_dump(),
+                },
+                {
+                    "id": uuid.UUID("2720b72d-0797-4f31-bde1-d54dccde093c"),
+                    "constraint_type": ConstraintType.MOON,
+                    "constraint_parameters": MoonAngleConstraint(
+                        min_angle=32.0,
+                    ).model_dump(),
+                },
+                {
+                    "id": uuid.UUID("6b6cbc6f-c2ec-423e-89cc-ed5f6cf03f56"),
+                    "constraint_type": ConstraintType.SUN,
+                    "constraint_parameters": SunAngleConstraint(
+                        min_angle=93.5,
+                    ).model_dump(),
+                },
+            ],
+        },
+    ],
+    "ephemeris_types": [
+        {
+            "id": uuid.UUID("08e0d5a5-02df-4aa6-8914-32186298c51d"),
+            "ephemeris_type": EphemerisType.TLE,
+            "priority": 1,
+            "parameters": {
+                "id": uuid.UUID("2fc62417-001e-450a-966c-0b731db14868"),
+                "norad_id": 63182,
+                "norad_satellite_name": "SPHEREX",
+            },
+        },
+    ],
+    "group": {
+        "id": uuid.UUID("984db8bc-d347-40f9-98f0-c7e3d8fc5619"),
+        "name": "Spectro-Photometer for the History of the Universe, Epoch of Reionization, and Ices Explorer",
+        "short_name": "SPHEREx",
+        "group_admin": {
+            "id": uuid.UUID("cc4ec1c1-e553-4e9a-9847-259181cd6c78"),
+            "name": "SPHEREx Group Admin",
+        },
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    session = orm.Session(bind=bind, expire_on_commit=False)
+
+    records = ssa_records.build(session, OBSERVATORY, snapshot_models)
+
+    session.add_all(records)
+    session.commit()
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    ssa_records.delete(session, OBSERVATORY, snapshot_models)
+
+    session.commit()

--- a/migrations/versions/_2026_04_21_1447-58b4ec651f87_add_spherex_observatory_data.py
+++ b/migrations/versions/_2026_04_21_1447-58b4ec651f87_add_spherex_observatory_data.py
@@ -7,6 +7,7 @@ Create Date: 2026-04-21 14:47:22.948075
 """
 
 import uuid
+from datetime import datetime
 from typing import Sequence, Union
 
 from across.tools import WavelengthBandpass
@@ -80,7 +81,7 @@ SPHEREX_BAND_4 = WavelengthBandpass(
     unit=tools_enums.WavelengthUnit.MICRON,
 )
 SPHEREX_BAND_5 = WavelengthBandpass(
-    filter_name="SPHEREx Band 1=5",
+    filter_name="SPHEREx Band 5",
     min=3.82,
     max=4.42,
     unit=tools_enums.WavelengthUnit.MICRON,
@@ -99,6 +100,7 @@ OBSERVATORY: dict = {
     "short_name": "SPHEREx",
     "type": ObservatoryType.SPACE_BASED.value,
     "reference_url": "https://spherex.caltech.edu",
+    "operational_begin_date": datetime(2025, 5, 1, 0, 0, 0),
     "telescopes": [
         {
             "id": uuid.UUID("0c8163cd-aff1-445e-9dc2-ec396aab0340"),
@@ -120,42 +122,42 @@ OBSERVATORY: dict = {
                     "filters": [
                         {
                             "id": uuid.UUID("71afe5a7-675e-4342-bb7c-3531e67d5778"),
-                            "name": "SPHEREx Band 1",
+                            "name": SPHEREX_BAND_1.filter_name,
                             "min_wavelength": SPHEREX_BAND_1.min,
                             "max_wavelength": SPHEREX_BAND_1.max,
                             "is_operational": True,
                         },
                         {
                             "id": uuid.UUID("b87bb481-572c-4648-9822-66020e150f75"),
-                            "name": "SPHEREx Band 2",
+                            "name": SPHEREX_BAND_2.filter_name,
                             "min_wavelength": SPHEREX_BAND_2.min,
                             "max_wavelength": SPHEREX_BAND_2.max,
                             "is_operational": True,
                         },
                         {
                             "id": uuid.UUID("5fad0293-e05f-4f8f-b8a5-1078cbe9eb61"),
-                            "name": "SPHEREx Band 3",
+                            "name": SPHEREX_BAND_3.filter_name,
                             "min_wavelength": SPHEREX_BAND_3.min,
                             "max_wavelength": SPHEREX_BAND_3.max,
                             "is_operational": True,
                         },
                         {
                             "id": uuid.UUID("303bca68-4b46-4c6e-a166-1fc68772bf5c"),
-                            "name": "SPHEREx Band 4",
+                            "name": SPHEREX_BAND_4.filter_name,
                             "min_wavelength": SPHEREX_BAND_4.min,
                             "max_wavelength": SPHEREX_BAND_4.max,
                             "is_operational": True,
                         },
                         {
                             "id": uuid.UUID("7e395b0e-a51e-448c-ad0d-becee5a151e5"),
-                            "name": "SPHEREx Band 5",
+                            "name": SPHEREX_BAND_5.filter_name,
                             "min_wavelength": SPHEREX_BAND_5.min,
                             "max_wavelength": SPHEREX_BAND_5.max,
                             "is_operational": True,
                         },
                         {
                             "id": uuid.UUID("dbd210bb-b2d2-48a5-84c3-edcee3ebf657"),
-                            "name": "SPHEREx Band 6",
+                            "name": SPHEREX_BAND_6.filter_name,
                             "min_wavelength": SPHEREX_BAND_6.min,
                             "max_wavelength": SPHEREX_BAND_6.max,
                             "is_operational": True,

--- a/migrations/versions/model_snapshots/models_2026_04_21.py
+++ b/migrations/versions/model_snapshots/models_2026_04_21.py
@@ -1,0 +1,667 @@
+import uuid
+from datetime import datetime, timezone
+
+from geoalchemy2 import Geography, WKBElement
+from sqlalchemy import (
+    JSON,
+    REAL,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.ext.asyncio import AsyncAttrs
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    mapped_column,
+    relationship,
+)
+
+from across_server.core.enums.visibility_type import VisibilityType
+from across_server.db.config import config
+
+base_metadata = MetaData(schema=config.ACROSS_DB_NAME, quote_schema=True)
+
+
+class Base(AsyncAttrs, DeclarativeBase):
+    metadata = base_metadata
+    id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+
+
+## Mixins ##
+class CreatableMixin:
+    created_by_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=True
+    )
+    created_on: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+
+class ModifiableMixin:
+    modified_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=True
+    )
+    modified_on: Mapped[datetime | None] = mapped_column(
+        DateTime,
+        nullable=True,
+        onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+
+## Associations/Join Tables ##
+user_group = Table(
+    "user_group",
+    Base.metadata,
+    Column("user_id", ForeignKey("user.id"), primary_key=True),
+    Column("group_id", ForeignKey("group.id"), primary_key=True),
+)
+
+user_role = Table(
+    "user_role",
+    Base.metadata,
+    Column("user_id", ForeignKey("user.id"), primary_key=True),
+    Column("role_id", ForeignKey("role.id"), primary_key=True),
+)
+
+user_group_role = Table(
+    "user_group_role",
+    Base.metadata,
+    Column("user_id", ForeignKey("user.id"), primary_key=True),
+    Column("group_role_id", ForeignKey("group_role.id"), primary_key=True),
+)
+
+user_service_account = Table(
+    "user_service_account",
+    Base.metadata,
+    Column("user_id", ForeignKey("user.id"), primary_key=True),
+    Column("service_account_id", ForeignKey("service_account.id"), primary_key=True),
+    # service_account_id can only appear once since SA can only be linked once PER user.
+    UniqueConstraint("service_account_id", name="uq_service_account_id"),
+)
+
+service_account_role = Table(
+    "service_account_role",
+    Base.metadata,
+    Column("service_account_id", ForeignKey("service_account.id"), primary_key=True),
+    Column("role_id", ForeignKey("role.id"), primary_key=True),
+)
+
+service_account_group_role = Table(
+    "service_account_group_role",
+    Base.metadata,
+    Column("service_account_id", ForeignKey("service_account.id"), primary_key=True),
+    Column("group_role_id", ForeignKey("group_role.id"), primary_key=True),
+)
+
+role_permission = Table(
+    "role_permission",
+    Base.metadata,
+    Column("permission_id", ForeignKey("permission.id"), primary_key=True),
+    Column("role_id", ForeignKey("role.id"), primary_key=True),
+)
+
+group_role_permission = Table(
+    "group_role_permission",
+    Base.metadata,
+    Column("permission_id", ForeignKey("permission.id"), primary_key=True),
+    Column("group_role_id", ForeignKey("group_role.id"), primary_key=True),
+)
+
+group_observatory = Table(
+    "group_observatory",
+    Base.metadata,
+    Column("group_id", ForeignKey("group.id"), primary_key=True),
+    Column("observatory_id", ForeignKey("observatory.id"), primary_key=True),
+)
+
+
+instrument_constraint = Table(
+    "instrument_constraint",
+    Base.metadata,
+    Column("instrument_id", ForeignKey("instrument.id"), primary_key=True),
+    Column("constraint_id", ForeignKey("constraint.id"), primary_key=True),
+)
+
+
+class EarthLocationParameters(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "earth_location_parameters"
+
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True
+    )
+    longitude: Mapped[float] = mapped_column(Float, nullable=False)
+    latitude: Mapped[float] = mapped_column(Float, nullable=False)
+    height: Mapped[float] = mapped_column(Float, nullable=False)
+
+
+class TLEParameters(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "tle_parameters"
+
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True
+    )
+    norad_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    norad_satellite_name: Mapped[str] = mapped_column(String(69), nullable=False)
+    __table_args__ = (
+        UniqueConstraint(
+            "norad_id", "observatory_id", name="uq_norad_id_observatory_id"
+        ),  # Enforce uniqueness
+    )
+
+
+class JPLEphemerisParameters(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "jpl_ephemeris_parameters"
+
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True
+    )
+    naif_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    __table_args__ = (
+        UniqueConstraint(
+            "naif_id", "observatory_id", name="uq_naif_id_observatory_id"
+        ),  # Enforce uniqueness
+    )
+
+
+class SpiceKernelParameters(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "spice_kernel_parameters"
+
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True
+    )
+    naif_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    spice_kernel_url: Mapped[str] = mapped_column(String(256), nullable=False)
+
+
+class ObservatoryEphemerisType(Base):
+    __tablename__ = "observatory_ephemeris_type"
+    __allow_unmapped__ = True
+
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("observatory.id"), primary_key=True
+    )
+    ephemeris_type: Mapped[str] = mapped_column(
+        String(10), nullable=False, primary_key=True
+    )
+    priority: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    parameters: Base | None = None
+
+    # Relationship to Observatory
+    observatory: Mapped["Observatory"] = relationship(
+        "Observatory", back_populates="ephemeris_types"
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "observatory_id",
+            "ephemeris_type",
+            "priority",
+            name="uq_observatory_type_priority",
+        ),
+    )
+
+
+# Application Models
+class GroupInvite(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "group_invite"
+
+    group_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("group.id"),
+    )
+    receiver_email: Mapped[str] = mapped_column(String(100))
+    receiver_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("user.id"),
+        nullable=True,
+    )
+    sender_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("user.id"),
+    )
+
+    receiver: Mapped["User"] = relationship(
+        back_populates="received_invites",
+        foreign_keys=[receiver_id],
+        lazy="selectin",
+    )
+
+    sender: Mapped["User"] = relationship(
+        back_populates="sent_invites",
+        foreign_keys=[sender_id],
+        lazy="selectin",
+    )
+
+    group: Mapped["Group"] = relationship(
+        back_populates="invites",
+        foreign_keys=[group_id],
+        lazy="selectin",
+    )
+
+
+class Permission(Base, CreatableMixin):
+    __tablename__ = "permission"
+
+    name: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+
+    roles: Mapped[list["Role"]] = relationship(
+        secondary=role_permission, back_populates="permissions", lazy="selectin"
+    )
+
+    group_roles: Mapped[list["GroupRole"]] = relationship(
+        secondary=group_role_permission, back_populates="permissions", lazy="selectin"
+    )
+
+
+class Role(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "role"
+
+    name: Mapped[str] = mapped_column(String(100))
+
+    users: Mapped[list["User"]] = relationship(
+        secondary=user_role, back_populates="roles", lazy="selectin"
+    )
+    permissions: Mapped[list["Permission"]] = relationship(
+        secondary=role_permission, back_populates="roles", lazy="selectin"
+    )
+    service_accounts: Mapped[list["ServiceAccount"] | None] = relationship(
+        secondary=service_account_role,
+        back_populates="roles",
+        lazy="selectin",
+    )
+
+
+class GroupRole(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "group_role"
+
+    name: Mapped[str] = mapped_column(String(100))
+    group_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("group.id")
+    )
+
+    group: Mapped["Group"] = relationship(
+        foreign_keys=[group_id], back_populates="roles"
+    )
+    users: Mapped[list["User"] | None] = relationship(
+        secondary=user_group_role, back_populates="group_roles", lazy="selectin"
+    )
+    service_accounts: Mapped[list["ServiceAccount"] | None] = relationship(
+        secondary=service_account_group_role,
+        back_populates="group_roles",
+        lazy="selectin",
+    )
+    permissions: Mapped[list["Permission"]] = relationship(
+        secondary=group_role_permission, back_populates="group_roles", lazy="selectin"
+    )
+
+
+class ServiceAccount(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "service_account"
+
+    expiration: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    expiration_duration: Mapped[int] = mapped_column(Integer, nullable=False)
+    hashed_key: Mapped[str] = mapped_column(String, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str] = mapped_column(String, nullable=True)
+
+    user: Mapped[list["User"]] = relationship(
+        secondary=user_service_account,
+        back_populates="service_accounts",
+        lazy="selectin",
+    )
+    roles: Mapped[list["Role"] | None] = relationship(
+        secondary=service_account_role,
+        back_populates="service_accounts",
+        lazy="selectin",
+    )
+    group_roles: Mapped[list["GroupRole"]] = relationship(
+        secondary=service_account_group_role,
+        back_populates="service_accounts",
+        lazy="selectin",
+    )
+
+
+class User(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "user"
+
+    username: Mapped[str] = mapped_column(String(25), index=True)
+    first_name: Mapped[str] = mapped_column(String(50))
+    last_name: Mapped[str] = mapped_column(String(50))
+    email: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
+
+    groups: Mapped[list["Group"]] = relationship(
+        secondary=user_group, back_populates="users", lazy="selectin"
+    )
+    roles: Mapped[list["Role"]] = relationship(
+        secondary=user_role, back_populates="users", lazy="selectin"
+    )
+    group_roles: Mapped[list["GroupRole"]] = relationship(
+        secondary=user_group_role, back_populates="users", lazy="selectin"
+    )
+    received_invites: Mapped[list["GroupInvite"]] = relationship(
+        back_populates="receiver",
+        lazy="selectin",
+        foreign_keys=[GroupInvite.receiver_id],
+    )
+    sent_invites: Mapped[list["GroupInvite"]] = relationship(
+        back_populates="sender",
+        lazy="selectin",
+        foreign_keys=[GroupInvite.sender_id],
+    )
+    service_accounts: Mapped[list["ServiceAccount"]] = relationship(
+        secondary=user_service_account,
+        back_populates="user",
+        lazy="selectin",
+    )
+
+
+class Group(Base, CreatableMixin, ModifiableMixin):
+    __tablename__: str = "group"
+
+    name: Mapped[str] = mapped_column(String(256))
+    short_name: Mapped[str] = mapped_column(String(25), index=True)
+
+    users: Mapped[list["User"]] = relationship(
+        secondary=user_group, back_populates="groups", lazy="selectin"
+    )
+    observatories: Mapped[list["Observatory"]] = relationship(
+        secondary=group_observatory, back_populates="group", lazy="selectin"
+    )
+    roles: Mapped[list["GroupRole"]] = relationship(
+        back_populates="group",
+        lazy="selectin",
+        cascade="all,delete",
+    )
+    invites: Mapped[list["GroupInvite"]] = relationship(
+        back_populates="group", lazy="selectin"
+    )
+
+
+class Observatory(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "observatory"
+
+    name: Mapped[str] = mapped_column(String(100))
+    short_name: Mapped[str] = mapped_column(String(50), nullable=True)
+    type: Mapped[str] = mapped_column(String(25), nullable=False)
+    reference_url: Mapped[str] = mapped_column(String, nullable=True)
+    is_operational: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    telescopes: Mapped[list["Telescope"]] = relationship(
+        back_populates="observatory", lazy="selectin", cascade="all,delete"
+    )
+    group: Mapped["Group"] = relationship(
+        secondary=group_observatory,
+        back_populates="observatories",
+        lazy="selectin",
+    )
+    ephemeris_types: Mapped[list["ObservatoryEphemerisType"]] = relationship(
+        "ObservatoryEphemerisType", back_populates="observatory", cascade="all,delete"
+    )
+    operational_begin_date: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True
+    )
+    operational_end_date: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True
+    )
+
+
+class Telescope(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "telescope"
+
+    name: Mapped[str] = mapped_column(String(100))
+    short_name: Mapped[str] = mapped_column(String(50), nullable=True)
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Observatory.id)
+    )
+    reference_url: Mapped[str] = mapped_column(String, nullable=True)
+    is_operational: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    observatory: Mapped["Observatory"] = relationship(
+        back_populates="telescopes", lazy="selectin"
+    )
+    instruments: Mapped[list["Instrument"]] = relationship(
+        back_populates="telescope", lazy="selectin", cascade="all,delete"
+    )
+    schedules: Mapped[list["Schedule"]] = relationship(
+        back_populates="telescope", lazy="noload"
+    )
+    schedule_cadences: Mapped[list["ScheduleCadence"]] = relationship(
+        back_populates="telescope", lazy="selectin", cascade="all,delete"
+    )
+
+
+class Instrument(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "instrument"
+
+    name: Mapped[str] = mapped_column(String(100))
+    short_name: Mapped[str] = mapped_column(String(50), nullable=True)
+    telescope_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Telescope.id)
+    )
+    type: Mapped[str] = mapped_column(String(50))
+    field_of_view: Mapped[str] = mapped_column(String(50))
+    reference_url: Mapped[str] = mapped_column(String, nullable=True)
+    is_operational: Mapped[bool] = mapped_column(Boolean, default=True)
+    observation_strategy: Mapped[str] = mapped_column(String(50))
+
+    telescope: Mapped["Telescope"] = relationship(
+        back_populates="instruments", lazy="selectin"
+    )
+    footprints: Mapped[list["Footprint"]] = relationship(
+        back_populates="instrument", lazy="selectin", cascade="all,delete"
+    )
+
+    observations: Mapped[list["Observation"]] = relationship(
+        back_populates="instrument", lazy="noload"
+    )
+    filters: Mapped[list["Filter"]] = relationship(
+        back_populates="instrument", lazy="selectin", cascade="all,delete"
+    )
+    visibility_type: Mapped[VisibilityType] = mapped_column(String(10), nullable=True)
+    constraints: Mapped[list["Constraint"]] = relationship(
+        secondary=instrument_constraint,
+        back_populates="instruments",
+        lazy="selectin",
+        cascade="all,delete",
+    )
+
+
+class Filter(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "filter"
+
+    name: Mapped[str] = mapped_column(String(50))
+    peak_wavelength: Mapped[float] = mapped_column(Float, nullable=True)
+    min_wavelength: Mapped[float] = mapped_column(Float)
+    max_wavelength: Mapped[float] = mapped_column(Float)
+    is_operational: Mapped[bool] = mapped_column(Boolean, default=True)
+    sensitivity_depth_unit: Mapped[str] = mapped_column(String(50), nullable=True)
+    sensitivity_depth: Mapped[float] = mapped_column(Float, nullable=True)
+    sensitivity_time_seconds: Mapped[float] = mapped_column(Float, nullable=True)
+    reference_url: Mapped[str] = mapped_column(String, nullable=True)
+    instrument_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Instrument.id)
+    )
+
+    instrument: Mapped["Instrument"] = relationship(
+        back_populates="filters", lazy="selectin"
+    )
+
+
+class Footprint(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "footprint"
+
+    instrument_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Instrument.id)
+    )
+    polygon: Mapped[WKBElement] = mapped_column(
+        Geography("POLYGON", srid=4326), nullable=True
+    )
+
+    instrument: Mapped["Instrument"] = relationship(
+        back_populates="footprints", lazy="selectin"
+    )
+
+
+class Schedule(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "schedule"
+
+    telescope_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Telescope.id)
+    )
+    date_range_begin: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    date_range_end: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False)
+    external_id: Mapped[str] = mapped_column(String(256), nullable=True)
+    name: Mapped[str] = mapped_column(String(256), nullable=False)
+    fidelity: Mapped[str] = mapped_column(String(50), default="high", nullable=False)
+    checksum: Mapped[str] = mapped_column(String(128), nullable=False)
+    observation_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    telescope: Mapped["Telescope"] = relationship(
+        back_populates="schedules", lazy="noload"
+    )
+
+    observations: Mapped[list["Observation"]] = relationship(
+        back_populates="schedule", lazy="selectin", cascade="all,delete"
+    )
+
+    __table_args__ = (
+        Index("ix_schedule_date_range", "date_range_begin", "date_range_end"),
+        Index("ix_schedule_date_range_begin", "date_range_begin"),
+        Index("ix_schedule_date_range_end", "date_range_end"),
+        Index("ix_schedule_checksum", "checksum", unique=True),
+    )
+
+
+class ScheduleCadence(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "schedule_cadence"
+
+    telescope_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Telescope.id)
+    )
+    schedule_status: Mapped[str] = mapped_column(String(50), nullable=False)
+    cron: Mapped[str] = mapped_column(String(50), nullable=True)
+    telescope: Mapped["Telescope"] = relationship(
+        back_populates="schedule_cadences", lazy="selectin"
+    )
+
+
+class Observation(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "observation"
+
+    instrument_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Instrument.id)
+    )
+    schedule_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Schedule.id)
+    )
+    object_name: Mapped[str] = mapped_column(String(100))
+    pointing_ra: Mapped[float | None] = mapped_column(REAL())
+    pointing_dec: Mapped[float | None] = mapped_column(REAL())
+    pointing_position: Mapped[WKBElement | None] = mapped_column(
+        Geography("POINT", srid=4326), nullable=True
+    )
+    date_range_begin: Mapped[datetime] = mapped_column(DateTime)
+    date_range_end: Mapped[datetime] = mapped_column(DateTime)
+    external_observation_id: Mapped[str] = mapped_column(String(50))
+    type: Mapped[str] = mapped_column(String(50))  # Enum
+    status: Mapped[str] = mapped_column(String(50))  # Enum
+    exposure_time: Mapped[float | None] = mapped_column(REAL())
+    reason: Mapped[str | None] = mapped_column(String(100))
+    description: Mapped[str | None] = mapped_column(String(100))
+    proposal_reference: Mapped[str | None] = mapped_column(String(100))
+    object_ra: Mapped[float | None] = mapped_column(REAL())
+    object_dec: Mapped[float | None] = mapped_column(REAL())
+    object_position: Mapped[WKBElement | None] = mapped_column(
+        Geography("POINT", srid=4326), nullable=True
+    )
+    pointing_angle: Mapped[float | None] = mapped_column(Float)
+    depth_value: Mapped[float | None] = mapped_column(REAL())
+    depth_unit: Mapped[str | None] = mapped_column(String(50))  # Enum
+    max_wavelength: Mapped[float | None] = mapped_column(Float)
+    min_wavelength: Mapped[float | None] = mapped_column(Float)
+    peak_wavelength: Mapped[float | None] = mapped_column(Float)
+    filter_name: Mapped[str | None] = mapped_column(String(50))
+
+    # explicit ivoa ObsLocTap definitions
+    t_resolution: Mapped[float | None] = mapped_column(Float, nullable=True)
+    em_res_power: Mapped[float | None] = mapped_column(Float, nullable=True)
+    o_ucd: Mapped[str | None] = mapped_column(String, nullable=True)
+    pol_states: Mapped[str | None] = mapped_column(String, nullable=True)
+    pol_xel: Mapped[str | None] = mapped_column(String, nullable=True)
+    category: Mapped[str | None] = mapped_column(String(50), nullable=True)  # Enum
+    priority: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tracking_type: Mapped[str | None] = mapped_column(String(50), nullable=True)  # Enum
+
+    instrument: Mapped["Instrument"] = relationship(
+        back_populates="observations", lazy="noload"
+    )
+    schedule: Mapped["Schedule"] = relationship(
+        back_populates="observations", lazy="selectin"
+    )
+    footprints: Mapped[list["ObservationFootprint"]] = relationship(
+        back_populates="observation", lazy="selectin", cascade="all,delete"
+    )
+
+
+class ObservationFootprint(Base):
+    __tablename__ = "observation_footprint"
+
+    observation_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Observation.id)
+    )
+    polygon: Mapped[WKBElement] = mapped_column(
+        Geography("POLYGON", srid=4326, spatial_index=True), nullable=False
+    )
+
+    observation: Mapped["Observation"] = relationship(
+        back_populates="footprints", lazy="selectin"
+    )
+
+    __table_args__ = (
+        Index("idx_observation_footprint_polygon", "polygon", postgresql_using="gist"),
+    )
+
+
+class TLE(Base):
+    __tablename__ = "tle"
+
+    norad_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    epoch: Mapped[datetime] = mapped_column(DateTime, nullable=False, primary_key=True)
+    satellite_name: Mapped[str] = mapped_column(String(69), nullable=False)
+    tle1: Mapped[str] = mapped_column(String(69), nullable=False)
+    tle2: Mapped[str] = mapped_column(String(69), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "epoch", "norad_id", name="uq_epoch_norad_id"
+        ),  # Enforce uniqueness
+    )
+
+
+class Constraint(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "constraint"
+
+    constraint_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    constraint_parameters: Mapped[dict] = mapped_column(JSON, nullable=False)
+
+    instruments: Mapped[list["Instrument"]] = relationship(
+        secondary=instrument_constraint,
+        back_populates="constraints",
+        lazy="selectin",
+    )


### PR DESCRIPTION
### Description

Adds SPHEREx data migration. SPHEREx is a unique instrument in that it is an imaging spectrometer--each image has a spatially varying central wavelength, meaning that the wavelength at which an object is observed in depends on where on the detector it falls. To better capture this, I've added a new `InstrumentType` value. 

Constraints were added based on published values [here](https://arxiv.org/pdf/2511.02985). Note that SPHEREx continues observing even during SAA passage, so I did not add an SAA constraint.

### Related Issue(s)

Resolves #562 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. Migrations should upgrade and downgrade

### Testing

1. Run `make reset` and verify migrations run successfully
2. Verify SPHEREx observatory metadata all looks correct