### PR TITLE
feat(migrations): adding pandora observatory migration

### DIFF
--- a/migrations/versions/_2026_04_21_1504-1d0298929d82_pandora_observatory_data.py
+++ b/migrations/versions/_2026_04_21_1504-1d0298929d82_pandora_observatory_data.py
@@ -1,0 +1,163 @@
+"""pandora observatory data
+
+Revision ID: 1d0298929d82
+Revises: a99c9ee52dce
+Create Date: 2026-04-21 15:04:36.524515
+
+"""
+
+import uuid
+from datetime import datetime
+from typing import Sequence, Union
+
+from across.tools.core.enums import ConstraintType
+from alembic import op
+from sqlalchemy import orm
+
+import migrations.versions.model_snapshots.models_2026_02_24 as snapshot_models
+from across_server.core.enums.ephemeris_type import EphemerisType
+from across_server.core.enums.instrument_fov import InstrumentFOV
+from across_server.core.enums.instrument_type import InstrumentType
+from across_server.core.enums.observatory_type import ObservatoryType
+from across_server.core.enums.visibility_type import VisibilityType
+from migrations.build_records import ssa_records
+from migrations.util.footprint_util import arcsec_to_deg, square_footprint
+
+# revision identifiers, used by Alembic.
+revision: str = "1d0298929d82"
+down_revision: Union[str, None] = "a99c9ee52dce"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+"""
+There isn't any information in the published documents on the FOV of the VISDA instrument
+These values are taken from https://github.com/PandoraMission/pandora-sat/blob/main/src/pandorasat/visibledetector.py file,
+and are used to calculate the FOV. It assumes that the entire 2048x2048 detector encompasses the image at the pixel scale.
+
+These values come to a square FOV of 0.445 degree sides.
+"""
+pixel_scale = 0.78301  # arcsec / pixel
+detector_shape = 2048  # pixel
+
+PANDORA_VISDA_FOOTPRINT = square_footprint(arcsec_to_deg(pixel_scale * detector_shape))
+
+VISDA_FILTERS = [
+    {
+        "id": uuid.UUID("66511f07-f27b-4a60-bb00-f6b113eef11d"),
+        "name": "VISDA",
+        "min_wavelength": 4000,
+        "max_wavelength": 6500,
+        "is_operational": True,
+        "reference_url": "https://arxiv.org/pdf/2108.06438",
+    },
+]
+
+NIRDA_FILTERS = [
+    {
+        "id": uuid.UUID("4f8088ce-dcf1-42dd-ad79-b774a2f5c646"),
+        "name": "NIRDA",
+        "min_wavelength": 10000,
+        "max_wavelength": 16000,
+        "is_operational": True,
+        "reference_url": "https://arxiv.org/pdf/2108.06438",
+    },
+]
+
+OBSERVATORY: dict = {
+    "id": uuid.UUID("d5417cb0-5f4f-4e79-9a81-49eb77cfaea7"),
+    "name": "Pandora Observatory",
+    "short_name": "Pandora",
+    "type": ObservatoryType.SPACE_BASED.value,
+    "reference_url": "https://pandorasat.com/",
+    "operational_begin_date": datetime(2026, 1, 12, 0, 0, 0),
+    "telescopes": [
+        {
+            "id": uuid.UUID("0b85e647-ffd6-4342-9183-d4e214ce02a2"),
+            "name": "Pandora Observatory",
+            "short_name": "Pandora",
+            "reference_url": "https://pandorasat.com/",
+            "instruments": [
+                {
+                    "id": uuid.UUID("5865b62e-179f-4e5b-9cd0-692d1ed84d4a"),
+                    "name": "Visible Detector",
+                    "short_name": "VISDA",
+                    "reference_url": "http://pandorasat.com/about/#pandora-payload",
+                    "type": InstrumentType.PHOTOMETRIC.value,
+                    "field_of_view": InstrumentFOV.POLYGON.value,
+                    "footprint": PANDORA_VISDA_FOOTPRINT,
+                    "filters": VISDA_FILTERS,
+                    "visibility_type": VisibilityType.EPHEMERIS,
+                },
+                {
+                    "id": uuid.UUID("6153c306-d100-4118-b859-b7230ff0480e"),
+                    "name": "NIR Detector",
+                    "short_name": "NIRDA",
+                    "reference_url": "http://pandorasat.com/about/#pandora-payload",
+                    "type": InstrumentType.SPECTROSCOPIC_LOW_RES.value,
+                    "field_of_view": InstrumentFOV.POINT,
+                    "filters": NIRDA_FILTERS,
+                    "visibility_type": VisibilityType.EPHEMERIS,
+                },
+            ],
+            # constraint information taken from section 2.1 of https://arxiv.org/pdf/2305.02285
+            "constraints": [
+                {
+                    "id": uuid.UUID("86398a06-4d2c-4765-aece-be1697cefd82"),
+                    "constraint_type": ConstraintType.SUN,
+                    "constraint_parameters": {"min_angle": 90},
+                },
+                {
+                    "id": uuid.UUID("9429b370-c6c1-4a14-afac-6040de3f9bbe"),
+                    "constraint_type": ConstraintType.EARTH,
+                    "constraint_parameters": {"min_angle": 20},
+                },
+                {
+                    "id": uuid.UUID("0d417d1c-50b8-4c35-8d12-ab4b3a93c851"),
+                    "constraint_type": ConstraintType.MOON,
+                    "constraint_parameters": {"min_angle": 40},
+                },
+            ],
+        }
+    ],
+    "ephemeris_types": [
+        {
+            "id": uuid.UUID("2a65aa6a-5999-4e1c-b149-0aeecf1dc8fb"),
+            "ephemeris_type": EphemerisType.TLE,
+            "priority": 1,
+            "parameters": {
+                "id": uuid.UUID("fa45448e-6aac-45dd-8101-3c1a58390c88"),
+                "norad_id": 98415,
+                "norad_satellite_name": "PANDORA",
+            },
+        },
+    ],
+    "group": {
+        "id": uuid.UUID("5a34835c-133f-447c-afc7-c5a9ea3c05e9"),
+        "name": "Pandora Observatory",
+        "short_name": "Pandora",
+        "group_admin": {
+            "id": uuid.UUID("5eb34da5-53dd-4f0c-9320-8cedd059f1ca"),
+            "name": "Pandora Group Admin",
+        },
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    session = orm.Session(bind=bind, expire_on_commit=False)
+
+    records = ssa_records.build(session, OBSERVATORY, snapshot_models)
+
+    session.add_all(records)
+    session.commit()
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    ssa_records.delete(session, OBSERVATORY, snapshot_models)
+
+    session.commit()

--- a/migrations/versions/_2026_04_21_1504-1d0298929d82_pandora_observatory_data.py
+++ b/migrations/versions/_2026_04_21_1504-1d0298929d82_pandora_observatory_data.py
@@ -14,10 +14,11 @@ from across.tools.core.enums import ConstraintType
 from alembic import op
 from sqlalchemy import orm
 
-import migrations.versions.model_snapshots.models_2026_02_24 as snapshot_models
+import migrations.versions.model_snapshots.models_2026_04_21 as snapshot_models
 from across_server.core.enums.ephemeris_type import EphemerisType
 from across_server.core.enums.instrument_fov import InstrumentFOV
 from across_server.core.enums.instrument_type import InstrumentType
+from across_server.core.enums.observation_strategy import ObservationStrategy
 from across_server.core.enums.observatory_type import ObservatoryType
 from across_server.core.enums.visibility_type import VisibilityType
 from migrations.build_records import ssa_records
@@ -77,6 +78,7 @@ OBSERVATORY: dict = {
             "name": "Pandora Observatory",
             "short_name": "Pandora",
             "reference_url": "https://pandorasat.com/",
+            "is_operational": True,
             "instruments": [
                 {
                     "id": uuid.UUID("5865b62e-179f-4e5b-9cd0-692d1ed84d4a"),
@@ -88,6 +90,8 @@ OBSERVATORY: dict = {
                     "footprint": PANDORA_VISDA_FOOTPRINT,
                     "filters": VISDA_FILTERS,
                     "visibility_type": VisibilityType.EPHEMERIS,
+                    "observation_strategy": ObservationStrategy.POINTED,
+                    "is_operational": True,
                 },
                 {
                     "id": uuid.UUID("6153c306-d100-4118-b859-b7230ff0480e"),
@@ -95,9 +99,12 @@ OBSERVATORY: dict = {
                     "short_name": "NIRDA",
                     "reference_url": "http://pandorasat.com/about/#pandora-payload",
                     "type": InstrumentType.SPECTROSCOPIC_LOW_RES.value,
-                    "field_of_view": InstrumentFOV.POINT,
+                    "field_of_view": InstrumentFOV.POINT.value,
                     "filters": NIRDA_FILTERS,
+                    "footprint": [],
                     "visibility_type": VisibilityType.EPHEMERIS,
+                    "observation_strategy": ObservationStrategy.POINTED,
+                    "is_operational": True,
                 },
             ],
             # constraint information taken from section 2.1 of https://arxiv.org/pdf/2305.02285

--- a/migrations/versions/_2026_04_21_1504-1d0298929d82_pandora_observatory_data.py
+++ b/migrations/versions/_2026_04_21_1504-1d0298929d82_pandora_observatory_data.py
@@ -1,7 +1,7 @@
 """pandora observatory data
 
 Revision ID: 1d0298929d82
-Revises: a99c9ee52dce
+Revises: 58b4ec651f87
 Create Date: 2026-04-21 15:04:36.524515
 
 """
@@ -26,7 +26,7 @@ from migrations.util.footprint_util import arcsec_to_deg, square_footprint
 
 # revision identifiers, used by Alembic.
 revision: str = "1d0298929d82"
-down_revision: Union[str, None] = "a99c9ee52dce"
+down_revision: Union[str, None] = "58b4ec651f87"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/migrations/versions/_2026_04_21_1504-1d0298929d82_pandora_observatory_data.py
+++ b/migrations/versions/_2026_04_21_1504-1d0298929d82_pandora_observatory_data.py
@@ -134,7 +134,7 @@ OBSERVATORY: dict = {
             "priority": 1,
             "parameters": {
                 "id": uuid.UUID("fa45448e-6aac-45dd-8101-3c1a58390c88"),
-                "norad_id": 98415,
+                "norad_id": 67395,
                 "norad_satellite_name": "PANDORA",
             },
         },

--- a/migrations/versions/model_snapshots/models_2026_04_21.py
+++ b/migrations/versions/model_snapshots/models_2026_04_21.py
@@ -1,0 +1,667 @@
+import uuid
+from datetime import datetime, timezone
+
+from geoalchemy2 import Geography, WKBElement
+from sqlalchemy import (
+    JSON,
+    REAL,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.ext.asyncio import AsyncAttrs
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    mapped_column,
+    relationship,
+)
+
+from across_server.core.enums.visibility_type import VisibilityType
+from across_server.db.config import config
+
+base_metadata = MetaData(schema=config.ACROSS_DB_NAME, quote_schema=True)
+
+
+class Base(AsyncAttrs, DeclarativeBase):
+    metadata = base_metadata
+    id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+
+
+## Mixins ##
+class CreatableMixin:
+    created_by_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=True
+    )
+    created_on: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+
+class ModifiableMixin:
+    modified_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=True
+    )
+    modified_on: Mapped[datetime | None] = mapped_column(
+        DateTime,
+        nullable=True,
+        onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+
+## Associations/Join Tables ##
+user_group = Table(
+    "user_group",
+    Base.metadata,
+    Column("user_id", ForeignKey("user.id"), primary_key=True),
+    Column("group_id", ForeignKey("group.id"), primary_key=True),
+)
+
+user_role = Table(
+    "user_role",
+    Base.metadata,
+    Column("user_id", ForeignKey("user.id"), primary_key=True),
+    Column("role_id", ForeignKey("role.id"), primary_key=True),
+)
+
+user_group_role = Table(
+    "user_group_role",
+    Base.metadata,
+    Column("user_id", ForeignKey("user.id"), primary_key=True),
+    Column("group_role_id", ForeignKey("group_role.id"), primary_key=True),
+)
+
+user_service_account = Table(
+    "user_service_account",
+    Base.metadata,
+    Column("user_id", ForeignKey("user.id"), primary_key=True),
+    Column("service_account_id", ForeignKey("service_account.id"), primary_key=True),
+    # service_account_id can only appear once since SA can only be linked once PER user.
+    UniqueConstraint("service_account_id", name="uq_service_account_id"),
+)
+
+service_account_role = Table(
+    "service_account_role",
+    Base.metadata,
+    Column("service_account_id", ForeignKey("service_account.id"), primary_key=True),
+    Column("role_id", ForeignKey("role.id"), primary_key=True),
+)
+
+service_account_group_role = Table(
+    "service_account_group_role",
+    Base.metadata,
+    Column("service_account_id", ForeignKey("service_account.id"), primary_key=True),
+    Column("group_role_id", ForeignKey("group_role.id"), primary_key=True),
+)
+
+role_permission = Table(
+    "role_permission",
+    Base.metadata,
+    Column("permission_id", ForeignKey("permission.id"), primary_key=True),
+    Column("role_id", ForeignKey("role.id"), primary_key=True),
+)
+
+group_role_permission = Table(
+    "group_role_permission",
+    Base.metadata,
+    Column("permission_id", ForeignKey("permission.id"), primary_key=True),
+    Column("group_role_id", ForeignKey("group_role.id"), primary_key=True),
+)
+
+group_observatory = Table(
+    "group_observatory",
+    Base.metadata,
+    Column("group_id", ForeignKey("group.id"), primary_key=True),
+    Column("observatory_id", ForeignKey("observatory.id"), primary_key=True),
+)
+
+
+instrument_constraint = Table(
+    "instrument_constraint",
+    Base.metadata,
+    Column("instrument_id", ForeignKey("instrument.id"), primary_key=True),
+    Column("constraint_id", ForeignKey("constraint.id"), primary_key=True),
+)
+
+
+class EarthLocationParameters(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "earth_location_parameters"
+
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True
+    )
+    longitude: Mapped[float] = mapped_column(Float, nullable=False)
+    latitude: Mapped[float] = mapped_column(Float, nullable=False)
+    height: Mapped[float] = mapped_column(Float, nullable=False)
+
+
+class TLEParameters(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "tle_parameters"
+
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True
+    )
+    norad_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    norad_satellite_name: Mapped[str] = mapped_column(String(69), nullable=False)
+    __table_args__ = (
+        UniqueConstraint(
+            "norad_id", "observatory_id", name="uq_norad_id_observatory_id"
+        ),  # Enforce uniqueness
+    )
+
+
+class JPLEphemerisParameters(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "jpl_ephemeris_parameters"
+
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True
+    )
+    naif_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    __table_args__ = (
+        UniqueConstraint(
+            "naif_id", "observatory_id", name="uq_naif_id_observatory_id"
+        ),  # Enforce uniqueness
+    )
+
+
+class SpiceKernelParameters(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "spice_kernel_parameters"
+
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True
+    )
+    naif_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    spice_kernel_url: Mapped[str] = mapped_column(String(256), nullable=False)
+
+
+class ObservatoryEphemerisType(Base):
+    __tablename__ = "observatory_ephemeris_type"
+    __allow_unmapped__ = True
+
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("observatory.id"), primary_key=True
+    )
+    ephemeris_type: Mapped[str] = mapped_column(
+        String(10), nullable=False, primary_key=True
+    )
+    priority: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    parameters: Base | None = None
+
+    # Relationship to Observatory
+    observatory: Mapped["Observatory"] = relationship(
+        "Observatory", back_populates="ephemeris_types"
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "observatory_id",
+            "ephemeris_type",
+            "priority",
+            name="uq_observatory_type_priority",
+        ),
+    )
+
+
+# Application Models
+class GroupInvite(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "group_invite"
+
+    group_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("group.id"),
+    )
+    receiver_email: Mapped[str] = mapped_column(String(100))
+    receiver_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("user.id"),
+        nullable=True,
+    )
+    sender_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("user.id"),
+    )
+
+    receiver: Mapped["User"] = relationship(
+        back_populates="received_invites",
+        foreign_keys=[receiver_id],
+        lazy="selectin",
+    )
+
+    sender: Mapped["User"] = relationship(
+        back_populates="sent_invites",
+        foreign_keys=[sender_id],
+        lazy="selectin",
+    )
+
+    group: Mapped["Group"] = relationship(
+        back_populates="invites",
+        foreign_keys=[group_id],
+        lazy="selectin",
+    )
+
+
+class Permission(Base, CreatableMixin):
+    __tablename__ = "permission"
+
+    name: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+
+    roles: Mapped[list["Role"]] = relationship(
+        secondary=role_permission, back_populates="permissions", lazy="selectin"
+    )
+
+    group_roles: Mapped[list["GroupRole"]] = relationship(
+        secondary=group_role_permission, back_populates="permissions", lazy="selectin"
+    )
+
+
+class Role(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "role"
+
+    name: Mapped[str] = mapped_column(String(100))
+
+    users: Mapped[list["User"]] = relationship(
+        secondary=user_role, back_populates="roles", lazy="selectin"
+    )
+    permissions: Mapped[list["Permission"]] = relationship(
+        secondary=role_permission, back_populates="roles", lazy="selectin"
+    )
+    service_accounts: Mapped[list["ServiceAccount"] | None] = relationship(
+        secondary=service_account_role,
+        back_populates="roles",
+        lazy="selectin",
+    )
+
+
+class GroupRole(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "group_role"
+
+    name: Mapped[str] = mapped_column(String(100))
+    group_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("group.id")
+    )
+
+    group: Mapped["Group"] = relationship(
+        foreign_keys=[group_id], back_populates="roles"
+    )
+    users: Mapped[list["User"] | None] = relationship(
+        secondary=user_group_role, back_populates="group_roles", lazy="selectin"
+    )
+    service_accounts: Mapped[list["ServiceAccount"] | None] = relationship(
+        secondary=service_account_group_role,
+        back_populates="group_roles",
+        lazy="selectin",
+    )
+    permissions: Mapped[list["Permission"]] = relationship(
+        secondary=group_role_permission, back_populates="group_roles", lazy="selectin"
+    )
+
+
+class ServiceAccount(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "service_account"
+
+    expiration: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    expiration_duration: Mapped[int] = mapped_column(Integer, nullable=False)
+    hashed_key: Mapped[str] = mapped_column(String, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str] = mapped_column(String, nullable=True)
+
+    user: Mapped[list["User"]] = relationship(
+        secondary=user_service_account,
+        back_populates="service_accounts",
+        lazy="selectin",
+    )
+    roles: Mapped[list["Role"] | None] = relationship(
+        secondary=service_account_role,
+        back_populates="service_accounts",
+        lazy="selectin",
+    )
+    group_roles: Mapped[list["GroupRole"]] = relationship(
+        secondary=service_account_group_role,
+        back_populates="service_accounts",
+        lazy="selectin",
+    )
+
+
+class User(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "user"
+
+    username: Mapped[str] = mapped_column(String(25), index=True)
+    first_name: Mapped[str] = mapped_column(String(50))
+    last_name: Mapped[str] = mapped_column(String(50))
+    email: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
+
+    groups: Mapped[list["Group"]] = relationship(
+        secondary=user_group, back_populates="users", lazy="selectin"
+    )
+    roles: Mapped[list["Role"]] = relationship(
+        secondary=user_role, back_populates="users", lazy="selectin"
+    )
+    group_roles: Mapped[list["GroupRole"]] = relationship(
+        secondary=user_group_role, back_populates="users", lazy="selectin"
+    )
+    received_invites: Mapped[list["GroupInvite"]] = relationship(
+        back_populates="receiver",
+        lazy="selectin",
+        foreign_keys=[GroupInvite.receiver_id],
+    )
+    sent_invites: Mapped[list["GroupInvite"]] = relationship(
+        back_populates="sender",
+        lazy="selectin",
+        foreign_keys=[GroupInvite.sender_id],
+    )
+    service_accounts: Mapped[list["ServiceAccount"]] = relationship(
+        secondary=user_service_account,
+        back_populates="user",
+        lazy="selectin",
+    )
+
+
+class Group(Base, CreatableMixin, ModifiableMixin):
+    __tablename__: str = "group"
+
+    name: Mapped[str] = mapped_column(String(256))
+    short_name: Mapped[str] = mapped_column(String(25), index=True)
+
+    users: Mapped[list["User"]] = relationship(
+        secondary=user_group, back_populates="groups", lazy="selectin"
+    )
+    observatories: Mapped[list["Observatory"]] = relationship(
+        secondary=group_observatory, back_populates="group", lazy="selectin"
+    )
+    roles: Mapped[list["GroupRole"]] = relationship(
+        back_populates="group",
+        lazy="selectin",
+        cascade="all,delete",
+    )
+    invites: Mapped[list["GroupInvite"]] = relationship(
+        back_populates="group", lazy="selectin"
+    )
+
+
+class Observatory(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "observatory"
+
+    name: Mapped[str] = mapped_column(String(100))
+    short_name: Mapped[str] = mapped_column(String(50), nullable=True)
+    type: Mapped[str] = mapped_column(String(25), nullable=False)
+    reference_url: Mapped[str] = mapped_column(String, nullable=True)
+    is_operational: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    telescopes: Mapped[list["Telescope"]] = relationship(
+        back_populates="observatory", lazy="selectin", cascade="all,delete"
+    )
+    group: Mapped["Group"] = relationship(
+        secondary=group_observatory,
+        back_populates="observatories",
+        lazy="selectin",
+    )
+    ephemeris_types: Mapped[list["ObservatoryEphemerisType"]] = relationship(
+        "ObservatoryEphemerisType", back_populates="observatory", cascade="all,delete"
+    )
+    operational_begin_date: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True
+    )
+    operational_end_date: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True
+    )
+
+
+class Telescope(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "telescope"
+
+    name: Mapped[str] = mapped_column(String(100))
+    short_name: Mapped[str] = mapped_column(String(50), nullable=True)
+    observatory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Observatory.id)
+    )
+    reference_url: Mapped[str] = mapped_column(String, nullable=True)
+    is_operational: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    observatory: Mapped["Observatory"] = relationship(
+        back_populates="telescopes", lazy="selectin"
+    )
+    instruments: Mapped[list["Instrument"]] = relationship(
+        back_populates="telescope", lazy="selectin", cascade="all,delete"
+    )
+    schedules: Mapped[list["Schedule"]] = relationship(
+        back_populates="telescope", lazy="noload"
+    )
+    schedule_cadences: Mapped[list["ScheduleCadence"]] = relationship(
+        back_populates="telescope", lazy="selectin", cascade="all,delete"
+    )
+
+
+class Instrument(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "instrument"
+
+    name: Mapped[str] = mapped_column(String(100))
+    short_name: Mapped[str] = mapped_column(String(50), nullable=True)
+    telescope_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Telescope.id)
+    )
+    type: Mapped[str] = mapped_column(String(50))
+    field_of_view: Mapped[str] = mapped_column(String(50))
+    reference_url: Mapped[str] = mapped_column(String, nullable=True)
+    is_operational: Mapped[bool] = mapped_column(Boolean, default=True)
+    observation_strategy: Mapped[str] = mapped_column(String(50))
+
+    telescope: Mapped["Telescope"] = relationship(
+        back_populates="instruments", lazy="selectin"
+    )
+    footprints: Mapped[list["Footprint"]] = relationship(
+        back_populates="instrument", lazy="selectin", cascade="all,delete"
+    )
+
+    observations: Mapped[list["Observation"]] = relationship(
+        back_populates="instrument", lazy="noload"
+    )
+    filters: Mapped[list["Filter"]] = relationship(
+        back_populates="instrument", lazy="selectin", cascade="all,delete"
+    )
+    visibility_type: Mapped[VisibilityType] = mapped_column(String(10), nullable=True)
+    constraints: Mapped[list["Constraint"]] = relationship(
+        secondary=instrument_constraint,
+        back_populates="instruments",
+        lazy="selectin",
+        cascade="all,delete",
+    )
+
+
+class Filter(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "filter"
+
+    name: Mapped[str] = mapped_column(String(50))
+    peak_wavelength: Mapped[float] = mapped_column(Float, nullable=True)
+    min_wavelength: Mapped[float] = mapped_column(Float)
+    max_wavelength: Mapped[float] = mapped_column(Float)
+    is_operational: Mapped[bool] = mapped_column(Boolean, default=True)
+    sensitivity_depth_unit: Mapped[str] = mapped_column(String(50), nullable=True)
+    sensitivity_depth: Mapped[float] = mapped_column(Float, nullable=True)
+    sensitivity_time_seconds: Mapped[float] = mapped_column(Float, nullable=True)
+    reference_url: Mapped[str] = mapped_column(String, nullable=True)
+    instrument_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Instrument.id)
+    )
+
+    instrument: Mapped["Instrument"] = relationship(
+        back_populates="filters", lazy="selectin"
+    )
+
+
+class Footprint(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "footprint"
+
+    instrument_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Instrument.id)
+    )
+    polygon: Mapped[WKBElement] = mapped_column(
+        Geography("POLYGON", srid=4326), nullable=True
+    )
+
+    instrument: Mapped["Instrument"] = relationship(
+        back_populates="footprints", lazy="selectin"
+    )
+
+
+class Schedule(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "schedule"
+
+    telescope_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Telescope.id)
+    )
+    date_range_begin: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    date_range_end: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False)
+    external_id: Mapped[str] = mapped_column(String(256), nullable=True)
+    name: Mapped[str] = mapped_column(String(256), nullable=False)
+    fidelity: Mapped[str] = mapped_column(String(50), default="high", nullable=False)
+    checksum: Mapped[str] = mapped_column(String(128), nullable=False)
+    observation_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    telescope: Mapped["Telescope"] = relationship(
+        back_populates="schedules", lazy="noload"
+    )
+
+    observations: Mapped[list["Observation"]] = relationship(
+        back_populates="schedule", lazy="selectin", cascade="all,delete"
+    )
+
+    __table_args__ = (
+        Index("ix_schedule_date_range", "date_range_begin", "date_range_end"),
+        Index("ix_schedule_date_range_begin", "date_range_begin"),
+        Index("ix_schedule_date_range_end", "date_range_end"),
+        Index("ix_schedule_checksum", "checksum", unique=True),
+    )
+
+
+class ScheduleCadence(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "schedule_cadence"
+
+    telescope_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Telescope.id)
+    )
+    schedule_status: Mapped[str] = mapped_column(String(50), nullable=False)
+    cron: Mapped[str] = mapped_column(String(50), nullable=True)
+    telescope: Mapped["Telescope"] = relationship(
+        back_populates="schedule_cadences", lazy="selectin"
+    )
+
+
+class Observation(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "observation"
+
+    instrument_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Instrument.id)
+    )
+    schedule_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Schedule.id)
+    )
+    object_name: Mapped[str] = mapped_column(String(100))
+    pointing_ra: Mapped[float | None] = mapped_column(REAL())
+    pointing_dec: Mapped[float | None] = mapped_column(REAL())
+    pointing_position: Mapped[WKBElement | None] = mapped_column(
+        Geography("POINT", srid=4326), nullable=True
+    )
+    date_range_begin: Mapped[datetime] = mapped_column(DateTime)
+    date_range_end: Mapped[datetime] = mapped_column(DateTime)
+    external_observation_id: Mapped[str] = mapped_column(String(50))
+    type: Mapped[str] = mapped_column(String(50))  # Enum
+    status: Mapped[str] = mapped_column(String(50))  # Enum
+    exposure_time: Mapped[float | None] = mapped_column(REAL())
+    reason: Mapped[str | None] = mapped_column(String(100))
+    description: Mapped[str | None] = mapped_column(String(100))
+    proposal_reference: Mapped[str | None] = mapped_column(String(100))
+    object_ra: Mapped[float | None] = mapped_column(REAL())
+    object_dec: Mapped[float | None] = mapped_column(REAL())
+    object_position: Mapped[WKBElement | None] = mapped_column(
+        Geography("POINT", srid=4326), nullable=True
+    )
+    pointing_angle: Mapped[float | None] = mapped_column(Float)
+    depth_value: Mapped[float | None] = mapped_column(REAL())
+    depth_unit: Mapped[str | None] = mapped_column(String(50))  # Enum
+    max_wavelength: Mapped[float | None] = mapped_column(Float)
+    min_wavelength: Mapped[float | None] = mapped_column(Float)
+    peak_wavelength: Mapped[float | None] = mapped_column(Float)
+    filter_name: Mapped[str | None] = mapped_column(String(50))
+
+    # explicit ivoa ObsLocTap definitions
+    t_resolution: Mapped[float | None] = mapped_column(Float, nullable=True)
+    em_res_power: Mapped[float | None] = mapped_column(Float, nullable=True)
+    o_ucd: Mapped[str | None] = mapped_column(String, nullable=True)
+    pol_states: Mapped[str | None] = mapped_column(String, nullable=True)
+    pol_xel: Mapped[str | None] = mapped_column(String, nullable=True)
+    category: Mapped[str | None] = mapped_column(String(50), nullable=True)  # Enum
+    priority: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tracking_type: Mapped[str | None] = mapped_column(String(50), nullable=True)  # Enum
+
+    instrument: Mapped["Instrument"] = relationship(
+        back_populates="observations", lazy="noload"
+    )
+    schedule: Mapped["Schedule"] = relationship(
+        back_populates="observations", lazy="selectin"
+    )
+    footprints: Mapped[list["ObservationFootprint"]] = relationship(
+        back_populates="observation", lazy="selectin", cascade="all,delete"
+    )
+
+
+class ObservationFootprint(Base):
+    __tablename__ = "observation_footprint"
+
+    observation_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey(Observation.id)
+    )
+    polygon: Mapped[WKBElement] = mapped_column(
+        Geography("POLYGON", srid=4326, spatial_index=True), nullable=False
+    )
+
+    observation: Mapped["Observation"] = relationship(
+        back_populates="footprints", lazy="selectin"
+    )
+
+    __table_args__ = (
+        Index("idx_observation_footprint_polygon", "polygon", postgresql_using="gist"),
+    )
+
+
+class TLE(Base):
+    __tablename__ = "tle"
+
+    norad_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    epoch: Mapped[datetime] = mapped_column(DateTime, nullable=False, primary_key=True)
+    satellite_name: Mapped[str] = mapped_column(String(69), nullable=False)
+    tle1: Mapped[str] = mapped_column(String(69), nullable=False)
+    tle2: Mapped[str] = mapped_column(String(69), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "epoch", "norad_id", name="uq_epoch_norad_id"
+        ),  # Enforce uniqueness
+    )
+
+
+class Constraint(Base, CreatableMixin, ModifiableMixin):
+    __tablename__ = "constraint"
+
+    constraint_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    constraint_parameters: Mapped[dict] = mapped_column(JSON, nullable=False)
+
+    instruments: Mapped[list["Instrument"]] = relationship(
+        secondary=instrument_constraint,
+        back_populates="constraints",
+        lazy="selectin",
+    )


### PR DESCRIPTION
### Description

This PR adds the data migration for the Pandora Small Sat Observatory.

### Related Issue(s)

#572 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

migrations run up and down, adding and removing the data respectively.

### Testing

adding - `alembic upgrade head`
removing - `alembic downgrade -1`
