### PR TITLE
feat(config): remove api root path prefix to support new domain

### DIFF
--- a/across_server/core/config.py
+++ b/across_server/core/config.py
@@ -54,7 +54,10 @@ class Config(BaseConfig):
         if self.is_local():
             return f"{self.HOST}:{self.PORT}{self.ROOT_PATH}"
         else:
-            return f"https://server.{self.RUNTIME_ENV.value}.across.smce.nasa.gov{self.ROOT_PATH}"
+            if self.RUNTIME_ENV == Environments.PRODUCTION:
+                return f"https://api.across.sciencecloud.nasa.gov{self.ROOT_PATH}"
+            else:
+                return f"https://api.{self.RUNTIME_ENV.value}.across.sciencecloud.nasa.gov{self.ROOT_PATH}"
 
 
 config = Config()

--- a/across_server/core/config.py
+++ b/across_server/core/config.py
@@ -15,7 +15,7 @@ class Config(BaseConfig):
     HOST: str = "http://localhost"
     FRONTEND_HOST: str = "http://localhost:5173"
     PORT: int = 8000
-    ROOT_PATH: str = "/api"
+    ROOT_PATH: str = ""
 
     SERVICE_ACCOUNT_EXPIRATION_DURATION: int = 30
 


### PR DESCRIPTION
### Description

This PR adjusts the config to remove the root path prefix `/api` to support the new api server domain name which will start with `api.`

### Related Issue(s)

Resolves #584 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

- api docs pages should operate unchanged
- api should respond to requests without an /api prefix to the root path

### Testing

1. Pull PR branch and run the server with `make dev`
2. verify the root path has been removed by visiting the docs
<img width="738" height="374" alt="image" src="https://github.com/user-attachments/assets/b5b1582f-a6db-4afe-9ccf-905e3647f25c" />

