### PR TITLE
feat(telescope): adding observatory qps to telescope get many

### DIFF
--- a/across_server/routes/v1/telescope/schemas.py
+++ b/across_server/routes/v1/telescope/schemas.py
@@ -101,6 +101,10 @@ class TelescopeRead(BaseSchema):
     ----------
     name: Optional[str] = None
         Query param to search by name or short name
+    observatory_id: Optional[UUID] = None
+        Query param to search by observatory id
+    observatory_name: Optional[str] = None
+        Query param to search by observatory name or short name
     instrument_id: Optional[UUID] = None
         Query param to search by instruments id
     instrument_name: Optional[str] = None
@@ -110,6 +114,8 @@ class TelescopeRead(BaseSchema):
     """
 
     name: str | None = None
+    observatory_id: uuid.UUID | None = None
+    observatory_name: str | None = None
     instrument_id: uuid.UUID | None = None
     instrument_name: str | None = None
     created_on: UTCDatetime | None = None

--- a/across_server/routes/v1/telescope/service.py
+++ b/across_server/routes/v1/telescope/service.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ....db import models
@@ -65,7 +65,7 @@ class TelescopeService:
         Parameters
         ----------
         data : schemas.TelescopeRead
-             class representing Telescope filter parameters
+            class representing Telescope filter parameters
         Returns
         -------
         list[sqlalchemy.filters]
@@ -83,6 +83,30 @@ class TelescopeService:
                 func.lower(models.Telescope.name).contains(str.lower(data.name))
                 | func.lower(models.Telescope.short_name).contains(str.lower(data.name))
             )
+
+        if data.observatory_id:
+            data_filter.append(models.Telescope.observatory_id == data.observatory_id)
+
+        if data.observatory_name:
+            observatory_name_or_filter = []
+
+            observatory_name_or_filter.append(
+                models.Telescope.observatory.has(
+                    func.lower(models.Observatory.name).contains(
+                        str.lower(data.observatory_name)
+                    )
+                )
+            )
+
+            observatory_name_or_filter.append(
+                models.Telescope.observatory.has(
+                    func.lower(models.Observatory.short_name).contains(
+                        str.lower(data.observatory_name)
+                    )
+                )
+            )
+
+            data_filter.append(or_(*observatory_name_or_filter))
 
         if data.instrument_id:
             data_filter.append(
@@ -115,7 +139,7 @@ class TelescopeService:
         Parameters
         ----------
         data : schemas.TelescopeRead
-             class representing Telescope filter parameters
+            class representing Telescope filter parameters
 
         Returns
         -------

--- a/across_server/routes/v1/telescope/service.py
+++ b/across_server/routes/v1/telescope/service.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ....db import models
@@ -88,25 +88,16 @@ class TelescopeService:
             data_filter.append(models.Telescope.observatory_id == data.observatory_id)
 
         if data.observatory_name:
-            observatory_name_or_filter = []
-
-            observatory_name_or_filter.append(
+            data_filter.append(
                 models.Telescope.observatory.has(
                     func.lower(models.Observatory.name).contains(
                         str.lower(data.observatory_name)
                     )
-                )
-            )
-
-            observatory_name_or_filter.append(
-                models.Telescope.observatory.has(
-                    func.lower(models.Observatory.short_name).contains(
+                    | func.lower(models.Observatory.short_name).contains(
                         str.lower(data.observatory_name)
                     )
                 )
             )
-
-            data_filter.append(or_(*observatory_name_or_filter))
 
         if data.instrument_id:
             data_filter.append(


### PR DESCRIPTION
### Description

This PR adds the query params for observatory name/id to the telescope get_many endpoint.

### Related Issue(s)

#594 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

Can query for Telescopes based on `observatory_name` and `observatory_id`.

### Testing

1. spin up server
2. navigate [to docs Telescope Get Many](http://127.0.0.1:8000/v1/docs#/Telescope/get_telescopes) 
3. use query params:
   * `observatory_name` - "ixpe" -> returns ixpe telescope
   * `observatory_id` - "9864f892-a980-442c-a0c9-f35e26e598dd" - returns ixpe telescope
 