### PR TITLE
feat: enable proxy-headers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,8 @@
                 "--host",
                 "127.0.0.1",
                 "--port",
-                "8000"
+                "8000",
+                "--proxy-headers"
             ],
             "jinja": true,
             "justMyCode": false

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,4 @@ EXPOSE 8000
 RUN useradd -m -u 5678 appuser && chown -R appuser /app
 USER appuser
 
-CMD ["uvicorn", "across_server.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "across_server.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers" ]

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ mfa: ## Auth with AWS through MFA
 start: check_prod run migrate seed ## Start the application containers (includes migrating and seeding)
 
 dev: local_only ## Start the server in the terminal
-	@$(VENV_BIN)/fastapi dev across_server/main.py
+	@$(VENV_BIN)/fastapi dev across_server/main.py --proxy-headers
 
 stop: local_only ## Stop the server container
 	@$(DOCKER_COMPOSE) down app

--- a/across_server/core/limiter/limiter.py
+++ b/across_server/core/limiter/limiter.py
@@ -18,12 +18,15 @@ jwt_auth = create_jwt_auth(
 
 
 async def authenticate_limit(scope: Scope) -> tuple[LimitKey, LimitGroup]:
-    ip: str
+    ip = "unknown"
 
     try:
         ip, _ = await client_ip(scope)
     except EmptyInformation:
-        ip = "unknown"
+        client = scope.get("client")
+
+        if client:
+            ip, _ = tuple(client)
 
     user_id: str  # uuid
     limit_group: str  # "user" or "service_account" if jwt, else "default"
@@ -39,6 +42,7 @@ async def authenticate_limit(scope: Scope) -> tuple[LimitKey, LimitGroup]:
     ):
         user_id = "anonymous"
         limit_group = "default"
+        # can add a debug log to see what it is otherwise the log will be called every time a normal GET request is called that doesn't have authentication information
 
     user_limit_key = f"{ip} {user_id}"
 


### PR DESCRIPTION
enable proxy headers for allowing x-forwarded-for headers.

Testing:

run local server with

```
FORWARDED_ALLOW_IPS=127.0.0.1 LIMIT_DEFAULT_REQUESTS_PER_MINUTE=1 uvicorn across_server.main:app --host 127.0.0.1 --port 8000 --proxy-headers
```

then make two calls and you should see the following logs:

```
2026-06-17T20:36:36.679249 [info     ] 1.1.1.1:0 - "GET /health HTTP/1.1" 200 [across_server.core.middleware.logging] duration=566625 http={'url': 'http://127.0.0.1:8000/health', 'status_code': 200, 'method': 'GET', 'version': '1.1'} network={'client': {'ip': '1.1.1.1', 'port': 0}} request_id=f718fa7b863a4a758fd182a648eb998b
2026-06-17T20:36:37.735624 [warning  ] Rate Limit Exceeded.           [across_server.core.limiter.limiter] access_token_id=anonymous client_ip=1.1.1.1 group=default path=/health request_id=31c1df58532147c1afa2e9727e215b24
```

here you can see that we properly log out the `client_ip` for rate limiting.