### PR TITLE
fix(migrations): update the pandora data migration

### DIFF
--- a/migrations/versions/_2026_06_17_1503-bb77d41c55c5_pandora_constraint_fix.py
+++ b/migrations/versions/_2026_06_17_1503-bb77d41c55c5_pandora_constraint_fix.py
@@ -37,7 +37,7 @@ def upgrade() -> None:
     sun_angle_update = (
         update(models.Constraint)
         .where(models.Constraint.id == "86398a06-4d2c-4765-aece-be1697cefd82")
-        .values(constraint_parameters=SunAngleConstraint(min_angle=90).model_dump())
+        .values(constraint_parameters=SunAngleConstraint(min_angle=90).model_dump())  # type: ignore
     )
     earth_limb_update = (
         update(models.Constraint)

--- a/migrations/versions/_2026_06_17_1503-bb77d41c55c5_pandora_constraint_fix.py
+++ b/migrations/versions/_2026_06_17_1503-bb77d41c55c5_pandora_constraint_fix.py
@@ -1,0 +1,60 @@
+"""pandora constraint fix
+
+Revision ID: bb77d41c55c5
+Revises: f24460b144c4
+Create Date: 2026-06-17 15:03:44.853744
+
+"""
+
+from typing import Sequence, Union
+
+from across.tools.visibility.constraints import (
+    EarthLimbConstraint,
+    MoonAngleConstraint,
+    SunAngleConstraint,
+)
+from alembic import op
+from sqlalchemy import orm, update
+
+import migrations.versions.model_snapshots.models_2026_05_26 as models
+
+# revision identifiers, used by Alembic.
+revision: str = "bb77d41c55c5"
+down_revision: Union[str, None] = "f24460b144c4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Update the Pandora constraints to have the correct parameter format.
+
+    The previous parameters were not in the correct format and caused errors when trying to use the visibility calculator.
+    """
+    bind = op.get_bind()
+    session = orm.Session(bind=bind, expire_on_commit=False)
+
+    sun_angle_update = (
+        update(models.Constraint)
+        .where(models.Constraint.id == "86398a06-4d2c-4765-aece-be1697cefd82")
+        .values(constraint_parameters=SunAngleConstraint(min_angle=90).model_dump())
+    )
+    earth_limb_update = (
+        update(models.Constraint)
+        .where(models.Constraint.id == "9429b370-c6c1-4a14-afac-6040de3f9bbe")
+        .values(constraint_parameters=EarthLimbConstraint(min_angle=20).model_dump())
+    )
+    moon_angle_update = (
+        update(models.Constraint)
+        .where(models.Constraint.id == "0d417d1c-50b8-4c35-8d12-ab4b3a93c851")
+        .values(constraint_parameters=MoonAngleConstraint(min_angle=40).model_dump())
+    )
+    session.execute(sun_angle_update)
+    session.execute(earth_limb_update)
+    session.execute(moon_angle_update)
+    session.commit()
+
+
+def downgrade() -> None:
+    """Downgrade is not supported for this migration as the previous constraint parameters were bad"""
+    pass


### PR DESCRIPTION
### Description

Migration fixes the pandora instrument constraints.

### Related Issue(s)

#628 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

Migrations run up and down
Pandora visibility calculator works again

### Testing

1. `alembic upgrade head` 🍏 
2. run local server and hit [this url](http://127.0.0.1:8000/v1/tools/visibility-calculator/windows/?ra=200&dec=45&date_range_begin=2026-06-14&date_range_end=2026-06-18&hi_res=true&min_visibility_duration=0&instrument_ids=5865b62e-179f-4e5b-9cd0-692d1ed84d4a) 🍏 
