### PR TITLE
fix: revise migrations to be rerun on deploy

### DIFF
--- a/migrations/versions/_2026_06_17_1503-bb77d41c55c5_pandora_constraint_fix.py
+++ b/migrations/versions/_2026_06_17_1503-bb77d41c55c5_pandora_constraint_fix.py
@@ -1,7 +1,7 @@
 """pandora constraint fix
 
 Revision ID: bb77d41c55c5
-Revises: f24460b144c4
+Revises: 572f3bb912a2
 Create Date: 2026-06-17 15:03:44.853744
 
 """
@@ -20,7 +20,7 @@ import migrations.versions.model_snapshots.models_2026_05_26 as models
 
 # revision identifiers, used by Alembic.
 revision: str = "bb77d41c55c5"
-down_revision: Union[str, None] = "f24460b144c4"
+down_revision: Union[str, None] = "572f3bb912a2"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/migrations/versions/_2026_06_18_1300-f24460b144c4_add_observation_schedule_id_idx.py
+++ b/migrations/versions/_2026_06_18_1300-f24460b144c4_add_observation_schedule_id_idx.py
@@ -1,7 +1,7 @@
 """add observation schedule id idx
 
-Revision ID: f24460b144c4
-Revises: 6a81b90801ad
+Revision ID: 43f24460b144
+Revises: bb77d41c55c5
 Create Date: 2026-06-10 13:19:22.539991
 
 """
@@ -11,8 +11,8 @@ from typing import Sequence, Union
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "f24460b144c4"
-down_revision: Union[str, None] = "6a81b90801ad"
+revision: str = "43f24460b144"
+down_revision: Union[str, None] = "bb77d41c55c5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/migrations/versions/_2026_06_18_1347-6a81b90801ad_adding_observation_request_models.py
+++ b/migrations/versions/_2026_06_18_1347-6a81b90801ad_adding_observation_request_models.py
@@ -1,7 +1,7 @@
 """adding observation request models
 
 Revision ID: 6a81b90801ad
-Revises: 572f3bb912a2
+Revises: 43f24460b144
 Create Date: 2026-05-26 13:47:37.611210
 
 """
@@ -17,7 +17,7 @@ import migrations.versions.model_snapshots.models_2026_05_26 as models
 
 # revision identifiers, used by Alembic.
 revision: str = "6a81b90801ad"
-down_revision: Union[str, None] = "572f3bb912a2"
+down_revision: Union[str, None] = "43f24460b144"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
two migrations were skipped on deploy somehow, this revises the IDs so that they should be picked up...