### PR TITLE
chore: add script to backfill projected observation footprints

### DIFF
--- a/scripts/project_observation_footprints.py
+++ b/scripts/project_observation_footprints.py
@@ -2,6 +2,7 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from itertools import batched
+from uuid import UUID
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -23,12 +24,12 @@ PROJECTION_BATCH_SIZE = 256
 
 
 def _project_observation_footprint(
-    observation_id: int,
+    observation_id: UUID,
     pointing_ra: float,
     pointing_dec: float,
     pointing_angle: float,
     detectors: list[list[dict[str, float]]],
-) -> tuple[int, list]:
+) -> tuple[UUID, list]:
     projected_footprints = footprint_util.project_footprint(
         detectors,
         pointing_ra,
@@ -47,7 +48,9 @@ def _project_observation_footprint(
     return observation_id, geometries
 
 
-async def project_footprints(observations, detectors):
+async def project_footprints(
+    observations: list[models.Observation], detectors: list[list[dict[str, float]]]
+) -> list:
     if not observations:
         return []
 
@@ -61,7 +64,7 @@ async def project_footprints(observations, detectors):
                 *[
                     loop.run_in_executor(
                         executor,
-                        _project_observation_footprint,
+                        _project_observation_footprint,  # type: ignore[arg-type]
                         observation.id,
                         observation.pointing_ra,
                         observation.pointing_dec,

--- a/scripts/project_observation_footprints.py
+++ b/scripts/project_observation_footprints.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import asyncio
 import time
+from itertools import batched
 
 import structlog
 from geoalchemy2 import shape
@@ -85,8 +86,8 @@ async def project_observation_footprints() -> None:
                     records.append(observation_footprint)
 
         logger.info("Committing to db")
-        for i in range(0, len(records), MAX_RECORDS_PER_WRITE):
-            chunk = records[i : i + MAX_RECORDS_PER_WRITE]
+        chunks = batched(records, MAX_RECORDS_PER_WRITE)
+        for _, chunk in enumerate(chunks):
             session.add_all(chunk)
             await session.commit()
 

--- a/scripts/project_observation_footprints.py
+++ b/scripts/project_observation_footprints.py
@@ -1,0 +1,84 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import asyncio
+
+from geoalchemy2 import shape
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from across_server.db import config, models
+from migrations.util import footprint_util
+
+MAX_RECORDS_PER_WRITE = 1000
+
+
+async def project_observation_footprints() -> None:
+    engine = create_async_engine(config.DB_URI)
+
+    async_session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with async_session() as session:
+        # Get all observations for each instrument
+        instrument_query = select(models.Instrument)
+        result = await session.execute(instrument_query)
+        instruments = result.scalars().all()
+
+        records = []
+
+        for instrument in instruments:
+            # Get observations for this instrument with pointing coordinates
+            # and no projected footprints
+            obs_query = select(models.Observation).where(
+                models.Observation.instrument_id == instrument.id,
+                models.Observation.pointing_ra.isnot(None),
+                models.Observation.pointing_dec.isnot(None),
+                ~models.Observation.footprints.any(),
+            )
+            obs_result = await session.execute(obs_query)
+            observations = obs_result.scalars().all()
+
+            detectors: list[list[dict[str, float]]] = []
+            for footprint in instrument.footprints:
+                poly = shape.to_shape(footprint.polygon)
+                x, y = poly.exterior.coords.xy  # type: ignore
+                detectors.append([{"x": x[i], "y": y[i]} for i in range(len(x))])
+
+            for observation in observations:
+                # Project the instrument footprint to the pointing position and save it
+                projected_footprints = footprint_util.project_footprint(
+                    detectors,
+                    observation.pointing_ra,  # type: ignore[arg-type]
+                    observation.pointing_dec,  # type: ignore[arg-type]
+                    observation.pointing_angle
+                    if observation.pointing_angle is not None
+                    else 0.0,
+                )
+
+                # convert the projected footprint to a list of FootprintPoints
+                for projected_footprint in projected_footprints:
+                    vertices = [
+                        footprint_util.ACROSSFootprintPoint(x=point["x"], y=point["y"])
+                        for point in projected_footprint
+                    ]
+
+                    wkb_footprint = footprint_util.create_geography(polygon=vertices)
+
+                    # create the footprint model record
+                    observation_footprint = models.ObservationFootprint(
+                        polygon=wkb_footprint, observation_id=observation.id
+                    )
+                    records.append(observation_footprint)
+
+        for i in range(0, len(records), MAX_RECORDS_PER_WRITE):
+            chunk = records[i : i + MAX_RECORDS_PER_WRITE]
+            session.add_all(chunk)
+            await session.commit()
+
+    return None
+
+
+if __name__ == "__main__":
+    asyncio.run(project_observation_footprints())

--- a/scripts/project_observation_footprints.py
+++ b/scripts/project_observation_footprints.py
@@ -1,30 +1,87 @@
 import os
 import sys
+from concurrent.futures import ThreadPoolExecutor
+from itertools import batched
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import asyncio
 import time
-from itertools import batched
 
 import structlog
 from geoalchemy2 import shape
 from sqlalchemy import select
 
-from across_server import db
 from across_server.db import database, models
 from migrations.util import footprint_util
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger()
 
 MAX_RECORDS_PER_WRITE = 1000
+MAX_PROJECTION_WORKERS = max(1, os.cpu_count() or 1)
+PROJECTION_BATCH_SIZE = 256
+
+
+def _project_observation_footprint(
+    observation_id: int,
+    pointing_ra: float,
+    pointing_dec: float,
+    pointing_angle: float,
+    detectors: list[list[dict[str, float]]],
+) -> tuple[int, list]:
+    projected_footprints = footprint_util.project_footprint(
+        detectors,
+        pointing_ra,
+        pointing_dec,
+        pointing_angle,
+    )
+
+    geometries = []
+    for projected_footprint in projected_footprints:
+        vertices = [
+            footprint_util.ACROSSFootprintPoint(x=point["x"], y=point["y"])
+            for point in projected_footprint
+        ]
+        geometries.append(footprint_util.create_geography(polygon=vertices))
+
+    return observation_id, geometries
+
+
+async def project_footprints(observations, detectors):
+    if not observations:
+        return []
+
+    loop = asyncio.get_running_loop()
+    max_workers = min(MAX_PROJECTION_WORKERS, len(observations))
+    footprints = []
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for observation_batch in batched(observations, PROJECTION_BATCH_SIZE):
+            batch_results = await asyncio.gather(
+                *[
+                    loop.run_in_executor(
+                        executor,
+                        _project_observation_footprint,
+                        observation.id,
+                        observation.pointing_ra,
+                        observation.pointing_dec,
+                        observation.pointing_angle
+                        if observation.pointing_angle is not None
+                        else 0.0,
+                        detectors,
+                    )
+                    for observation in observation_batch
+                ]
+            )
+            footprints.extend(batch_results)
+
+    return footprints
 
 
 async def project_observation_footprints() -> None:
-    logger.info("Starting project_observation_footprints")
     start_time = time.perf_counter()
 
-    db.init()
+    database.init()
 
     async with database.async_session() as session:
         # Get all observations for each instrument
@@ -57,44 +114,27 @@ async def project_observation_footprints() -> None:
                 detectors.append([{"x": x[i], "y": y[i]} for i in range(len(x))])
 
             logger.info("Projecting footprints for %s observations", len(observations))
-            for observation in observations:
-                # Project the instrument footprint to the pointing position and save it
-                projected_footprints = footprint_util.project_footprint(
-                    detectors,
-                    observation.pointing_ra,  # type: ignore[arg-type]
-                    observation.pointing_dec,  # type: ignore[arg-type]
-                    observation.pointing_angle
-                    if observation.pointing_angle is not None
-                    else 0.0,
-                )
+            footprints = await project_footprints(observations, detectors)
 
-                # convert the projected footprint to a list of FootprintPoints
-                for projected_footprint in projected_footprints:
-                    vertices = [
-                        footprint_util.ACROSSFootprintPoint(x=point["x"], y=point["y"])
-                        for point in projected_footprint
-                    ]
-
-                    wkb_footprint = footprint_util.create_geography(polygon=vertices)
-
-                    # create the footprint model record
-                    observation_footprint = models.ObservationFootprint(
-                        polygon=wkb_footprint, observation_id=observation.id
+            for observation_id, geometries in footprints:
+                for wkb_footprint in geometries:
+                    records.append(
+                        models.ObservationFootprint(
+                            polygon=wkb_footprint,
+                            observation_id=observation_id,
+                        )
                     )
-                    records.append(observation_footprint)
+
+        chunks = batched(records, MAX_RECORDS_PER_WRITE)
 
         logger.info("Committing to db")
-        chunks = batched(records, MAX_RECORDS_PER_WRITE)
         for _, chunk in enumerate(chunks):
             session.add_all(chunk)
             await session.commit()
 
-        elapsed_seconds = time.perf_counter() - start_time
-        mins, secs = map(int, divmod(elapsed_seconds, 60))
-
-        logger.info(f"Done. Took: {mins} min {secs} sec")
-
-    return None
+    elapsed_seconds = time.perf_counter() - start_time
+    mins, secs = map(int, divmod(elapsed_seconds, 60))
+    logger.info(f"Done. took: {mins} min {secs} sec")
 
 
 if __name__ == "__main__":

--- a/scripts/project_observation_footprints.py
+++ b/scripts/project_observation_footprints.py
@@ -10,9 +10,9 @@ from itertools import batched
 import structlog
 from geoalchemy2 import shape
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from across_server.db import config, models
+from across_server import db
+from across_server.db import database, models
 from migrations.util import footprint_util
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger()
@@ -24,11 +24,9 @@ async def project_observation_footprints() -> None:
     logger.info("Starting project_observation_footprints")
     start_time = time.perf_counter()
 
-    engine = create_async_engine(config.DB_URI)
+    db.init()
 
-    async_session = async_sessionmaker(engine, expire_on_commit=False)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
         # Get all observations for each instrument
         instrument_query = select(models.Instrument)
         result = await session.execute(instrument_query)

--- a/scripts/project_observation_footprints.py
+++ b/scripts/project_observation_footprints.py
@@ -4,7 +4,9 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import asyncio
+import time
 
+import structlog
 from geoalchemy2 import shape
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -12,10 +14,15 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from across_server.db import config, models
 from migrations.util import footprint_util
 
+logger: structlog.stdlib.BoundLogger = structlog.get_logger()
+
 MAX_RECORDS_PER_WRITE = 1000
 
 
 async def project_observation_footprints() -> None:
+    logger.info("Starting project_observation_footprints")
+    start_time = time.perf_counter()
+
     engine = create_async_engine(config.DB_URI)
 
     async_session = async_sessionmaker(engine, expire_on_commit=False)
@@ -28,7 +35,11 @@ async def project_observation_footprints() -> None:
 
         records = []
 
-        for instrument in instruments:
+        for index, instrument in enumerate(instruments, start=1):
+            logger.info(
+                f"({index}/{len(instruments)}) Gathering observations for {instrument.name}"
+            )
+
             # Get observations for this instrument with pointing coordinates
             # and no projected footprints
             obs_query = select(models.Observation).where(
@@ -46,6 +57,7 @@ async def project_observation_footprints() -> None:
                 x, y = poly.exterior.coords.xy  # type: ignore
                 detectors.append([{"x": x[i], "y": y[i]} for i in range(len(x))])
 
+            logger.info("Projecting footprints for %s observations", len(observations))
             for observation in observations:
                 # Project the instrument footprint to the pointing position and save it
                 projected_footprints = footprint_util.project_footprint(
@@ -72,10 +84,16 @@ async def project_observation_footprints() -> None:
                     )
                     records.append(observation_footprint)
 
+        logger.info("Committing to db")
         for i in range(0, len(records), MAX_RECORDS_PER_WRITE):
             chunk = records[i : i + MAX_RECORDS_PER_WRITE]
             session.add_all(chunk)
             await session.commit()
+
+        elapsed_seconds = time.perf_counter() - start_time
+        mins, secs = map(int, divmod(elapsed_seconds, 60))
+
+        logger.info(f"Done. Took: {mins} min {secs} sec")
 
     return None
 


### PR DESCRIPTION
### Description

This PR adds a script to backfill projected observation footprints for observations in the db. This is intended to be run once against a given deployed env, and can be run locally. 

I tested this against a local copy of the production database with >900k observations and it took a bit over an hour to run. 

### Related Issue(s)

Resolves #618

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. Instrument footprints should be projected and saved as `ObservationFootprint` objects for each observation in the database
2. Should not project footprints for observations that already have footprint information

### Testing

1. In the root of this repo run `.venv/bin/python scripts/project_observation_footprints.py` 
2. Verify project observation footprints are saved
3. Rerun this command and verify footprints are not re-projected and saved