### PR TITLE
feat(seed): add local treedome automation service account with schedule write for sandy seeded user

### DIFF
--- a/migrations/seeds/service_accounts.py
+++ b/migrations/seeds/service_accounts.py
@@ -1,0 +1,28 @@
+import datetime
+import uuid
+
+from across_server.auth.hashing import password_hasher
+from across_server.db.models import ServiceAccount
+
+from .group_roles import treedome_schedule_operations
+
+# use these client credentials to authenticate locally in across-client as this service account
+client_id = "961fbb3b-dd5e-45ff-a282-41033e43933d"
+client_secret = "prehibernationweek"
+
+# hash the secret key for storage in database
+hashed_secret_key = password_hasher.hash(str(client_secret))
+# very far away expiration
+expiration_date = datetime.datetime.fromisoformat("2126-01-01 00:00:00")
+
+treedome_automation_service_account = ServiceAccount(
+    id=uuid.UUID(client_id),
+    hashed_key=hashed_secret_key,
+    name="Treedome Automation",
+    description="Seeded service account for local testing",
+    expiration=expiration_date,
+    expiration_duration=36525,
+    group_roles=[treedome_schedule_operations],
+)
+
+service_accounts = [treedome_automation_service_account]

--- a/migrations/seeds/users.py
+++ b/migrations/seeds/users.py
@@ -5,6 +5,7 @@ from across_server.db.models import User
 from .group_roles import treedome_group_admin, treedome_schedule_operations
 from .groups import treedome_space_group
 from .roles import across_admin_role
+from .service_accounts import treedome_automation_service_account
 
 dev = User(
     id=uuid.UUID("173e35fa-9544-49e8-b5b9-d04ea884defb"),
@@ -27,6 +28,7 @@ sandy = User(
     modified_by_id=None,
     group_roles=[treedome_group_admin, treedome_schedule_operations],
     groups=[treedome_space_group],
+    service_accounts=[treedome_automation_service_account],
 )
 
 spongebob = User(


### PR DESCRIPTION
### Description

This PR adds a local service account for Sandy's user `sandy@treedome.space` which can be used to test service account level functionality and creating schedules with observations for the `Treedome Space Group` Observatory Telescopes

### Related Issue(s)

Resolves #625 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

- Sandy's local seeded service account can be used without requiring installation of across-frontend to make a service account and test schedule posting functionality

### Testing

- pull branch
- `make seed`
- verify the new service account exists in the local database
   <img width="911" height="72" alt="image" src="https://github.com/user-attachments/assets/c7273e49-5389-4063-b7f3-25c5dbe992a6" />  
- verify `across-client` can be used to authenticate locally with seeded service account

optional:
- verify in across-frontend that local service account renders
   <img width="1705" height="507" alt="image" src="https://github.com/user-attachments/assets/af919857-edd7-4791-8e61-7def24bdb131" />  
