### PR TITLE
fix(db): add/rename missing indexes in models.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,9 @@ migrate: ## Run the migrations for the database
 		echo "Migrations are only allowed in runtime ENVs: local, dev."; \
 	fi
 
+db_check:
+	@$(VENV_BIN) alembic check
+
 # Group: Running
 run: ## Run the containers
 	@$(DOCKER_COMPOSE) up -d --wait --wait-timeout 30

--- a/across_server/db/models.py
+++ b/across_server/db/models.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     String,
     Table,
     UniqueConstraint,
+    desc,
 )
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.ext.asyncio import AsyncAttrs
@@ -638,6 +639,76 @@ class Observation(Base, CreatableMixin, ModifiableMixin):
         back_populates="observation", lazy="noload", cascade="all,delete"
     )
 
+    __table_args__ = (
+        # Covering index: instrument_id is a broad filter.
+        # Include: status and type on index leaves to accelerate common compound filters
+        Index(
+            "ix_across_observation_instrument_created_id",
+            "instrument_id",
+            desc("created_on"),
+            desc("id"),
+            postgresql_include=["status", "type"],
+        ),
+        # Covering index: status is a broad filter.
+        # Include: type and instrument_id on index leaves to accelerate common compound filters
+        Index(
+            "ix_across_observation_status_created_id",
+            "status",
+            desc("created_on"),
+            desc("id"),
+            postgresql_include=["instrument_id", "type"],
+        ),
+        # Plain composite indexes for remaining filter columns.
+        Index(
+            "ix_across_observation_type_created_id",
+            "type",
+            desc("created_on"),
+            desc("id"),
+        ),
+        Index(
+            "ix_across_observation_date_range_end_created_id",
+            "date_range_end",
+            desc("created_on"),
+            desc("id"),
+        ),
+        Index(
+            "ix_across_observation_date_range_begin_created_id",
+            "date_range_begin",
+            desc("created_on"),
+            desc("id"),
+        ),
+        Index(
+            "ix_across_observation_min_wavelength_created_id",
+            "min_wavelength",
+            desc("created_on"),
+            desc("id"),
+        ),
+        Index(
+            "ix_across_observation_max_wavelength_created_id",
+            "max_wavelength",
+            desc("created_on"),
+            desc("id"),
+        ),
+        Index(
+            "ix_across_observation_depth_value_created_id",
+            "depth_value",
+            desc("created_on"),
+            desc("id"),
+        ),
+        Index(
+            "ix_across_observation_depth_unit_created_id",
+            "depth_unit",
+            desc("created_on"),
+            desc("id"),
+        ),
+        # Default sort composite — created_on + id for no-filter pagination
+        Index(
+            "ix_across_observation_created_on_id",
+            desc("created_on"),
+            desc("id"),
+        ),
+    )
+
 
 class ObservationFootprint(Base):
     __tablename__ = "observation_footprint"
@@ -837,11 +908,13 @@ class ObservationRequest(Base, CreatableMixin, ModifiableMixin):
 
     __table_args__ = (
         Index(
-            "ix_observation_request_object_position",
+            "ix_across_observation_request_object_position",
             "object_position",
             postgresql_using="gist",
         ),
         Index(
-            "ix_observation_request_date_range", "date_range_begin", "date_range_end"
+            "ix_across_observation_request_date_range",
+            "date_range_begin",
+            "date_range_end",
         ),
     )


### PR DESCRIPTION
### Description

Add missing indexes that were created in migrations, but were missing from models.py.
Rename indexes that were "missing"

 - adds alembic check command for checking db migration drift to Makefile

### Related Issue(s)

Resolves #673 ([really resolved with the alembic check workflow PR](https://github.com/NASA-ACROSS/github-action-workflows/pull/7) but this ticket talks about it)
Resolves #674 

### Acceptance Criteria

1. should run `make rev` without generating new changes

### Testing

1. `make rev TITLE="test"`
2. open migration file, see no changes ✅ 

