### PR TITLE
feat: limit pagination params and return empty array when out of bounds

### DIFF
--- a/across_server/core/config.py
+++ b/across_server/core/config.py
@@ -45,7 +45,16 @@ class Config(BaseConfig):
     APP_SUMMARY: str = "Astrophysics Cross-Observatory Science Support (ACROSS)"
     APP_DESCRIPTION: str = "Server providing tools and utilities for various NASA missions to aid in coordination of large observation efforts."
 
+    # Pagination parameters
+    # As of writing, we have ~1.1 million rows in observations table
+    # Currently as set allows retrieval up to 2 million results (DEFAULT_PAGE_MAX * DEFAULT_PAGE_LIMIT_MAX)
+    DEFAULT_PAGE: int = 1
+    DEFAULT_PAGE_MIN: int = 1
+    DEFAULT_PAGE_MAX: int = 2000
+
     DEFAULT_PAGE_LIMIT: int = 100
+    DEFAULT_PAGE_LIMIT_MIN: int = 100
+    DEFAULT_PAGE_LIMIT_MAX: int = 1000
 
     def is_local(self) -> bool:
         return self.RUNTIME_ENV == Environments.LOCAL

--- a/across_server/core/schemas/pagination.py
+++ b/across_server/core/schemas/pagination.py
@@ -7,11 +7,16 @@ from ...core.schemas.base import BaseSchema
 
 
 class PaginationParams(BaseSchema):
-    page: int | None = Field(default=1, ge=1, description="Page number")
+    page: int | None = Field(
+        default=config.DEFAULT_PAGE,
+        ge=config.DEFAULT_PAGE_MIN,
+        le=config.DEFAULT_PAGE_MAX,
+        description="Page number",
+    )
     page_limit: int | None = Field(
         default=config.DEFAULT_PAGE_LIMIT,
-        ge=1,
-        le=10000,
+        ge=config.DEFAULT_PAGE_LIMIT_MIN,
+        le=config.DEFAULT_PAGE_LIMIT_MAX,
         description="Records per page",
     )
 

--- a/across_server/routes/v1/observation/service.py
+++ b/across_server/routes/v1/observation/service.py
@@ -383,6 +383,15 @@ class ObservationService:
         )
         total_count = (await self.db.execute(count_query)).scalar_one()
 
+        # Raise when page requests out of bounds of requested data length
+        if data.page and data.page_limit:
+            request_total_data_start = data.page * data.page_limit
+
+            if total_count < request_total_data_start:
+                raise InvalidObservationReadParametersException(
+                    "Page and limit selections out of range"
+                )
+
         # query to find the ids quickly with indexes and leaf info
         nested_id_subq = (
             select(models.Observation.id)

--- a/across_server/routes/v1/observation/service.py
+++ b/across_server/routes/v1/observation/service.py
@@ -388,9 +388,7 @@ class ObservationService:
             request_total_data_start = data.page * data.page_limit
 
             if total_count < request_total_data_start:
-                raise InvalidObservationReadParametersException(
-                    "Page and limit selections out of range"
-                )
+                return [], total_count
 
         # query to find the ids quickly with indexes and leaf info
         nested_id_subq = (

--- a/across_server/routes/v1/observation/service.py
+++ b/across_server/routes/v1/observation/service.py
@@ -385,7 +385,7 @@ class ObservationService:
 
         # Raise when page requests out of bounds of requested data length
         if data.page and data.page_limit:
-            request_total_data_start = data.page * data.page_limit
+            request_total_data_start = (data.page - 1) * data.page_limit
 
             if total_count < request_total_data_start:
                 return [], total_count

--- a/across_server/routes/v1/observation/service.py
+++ b/across_server/routes/v1/observation/service.py
@@ -383,7 +383,7 @@ class ObservationService:
         )
         total_count = (await self.db.execute(count_query)).scalar_one()
 
-        # Raise when page requests out of bounds of requested data length
+        # early return no data when page requests out of bounds of requested data length
         if data.page and data.page_limit:
             request_total_data_start = (data.page - 1) * data.page_limit
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,12 @@ def mock_scalar_one_or_none() -> Generator[MagicMock]:
 
 
 @pytest.fixture
+def mock_scalar_one() -> Generator[MagicMock]:
+    mock = MagicMock()
+    yield mock
+
+
+@pytest.fixture
 def mock_scalars() -> Generator[MagicMock]:
     mock = MagicMock()
     yield mock
@@ -74,12 +80,14 @@ def mock_tuples() -> Generator[MagicMock]:
 @pytest.fixture
 def mock_result(
     mock_scalar_one_or_none: MagicMock,
+    mock_scalar_one: MagicMock,
     mock_scalars: MagicMock,
     mock_unique: MagicMock,
     mock_tuples: MagicMock,
 ) -> Generator[MagicMock]:
     mock = MagicMock()
     mock.unique = MagicMock(return_value=mock_unique)
+    mock.scalar_one = mock_scalar_one
     mock.scalar_one_or_none = mock_scalar_one_or_none
     mock.scalars = mock_scalars
     mock.tuples = mock_tuples

--- a/tests/core/schemas/conftest.py
+++ b/tests/core/schemas/conftest.py
@@ -3,4 +3,4 @@ import pytest
 
 @pytest.fixture
 def mock_pagination_data() -> dict:
-    return {"page": 3, "page_limit": 10}
+    return {"page": 3, "page_limit": 100}

--- a/tests/routes/v1/observation/service_test.py
+++ b/tests/routes/v1/observation/service_test.py
@@ -49,7 +49,7 @@ class TestObservationService:
             self, mock_db: AsyncMock, mock_result: AsyncMock
         ) -> None:
             """Should return empty list when nothing matches params"""
-            mock_result.scalars.return_value.all.return_value = []
+            mock_result.scalar_one.return_value = 0
 
             service = ObservationService(mock_db)
             params = ObservationRead()

--- a/tests/routes/v1/observation/service_test.py
+++ b/tests/routes/v1/observation/service_test.py
@@ -45,6 +45,20 @@ class TestObservationService:
 
     class TestGetMany:
         @pytest.mark.asyncio
+        async def test_should_return_empty_list_when_page_and_page_limit_greater_than_total(
+            self, mock_db: AsyncMock, mock_result: AsyncMock
+        ) -> None:
+            """Should return empty list when pagination parameters are out of range > total"""
+            mock_result.scalar_one.return_value = 1
+
+            service = ObservationService(mock_db)
+            params = ObservationRead()
+            params.page = 10
+            params.page_limit = 100
+            observations, total_count = await service.get_many(params)
+            assert len(observations) == 0
+
+        @pytest.mark.asyncio
         async def test_should_return_empty_list_when_nothing_matches_params(
             self, mock_db: AsyncMock, mock_result: AsyncMock
         ) -> None:


### PR DESCRIPTION
## Description

- limit pagination params in the validator with config
- raise when pagination out of bounds for observation request total_count

### Resolved Issue(s)

Resolves #689 

## Acceptance Criteria

- the server should deny "unreasonably large" page numbers
- the server should return an empty array when page request is out of bounds of total_count for query parameters to be returned

## Testing

1. pull repo, start server, make a large request to the local server

this one should fail because page is too big for the validator
http://localhost:8000/v1/observation/?schedule_ids=14cd6a89-b9ab-4116-a3b0-0c83086a7677&page=12345678&page_limit=100

this one should not fail, but return an empty array, because page*page_limit is greater than the total_number of requests to be returned
http://localhost:8000/v1/observation/?schedule_ids=14cd6a89-b9ab-4116-a3b0-0c83086a7677&page=1234&page_limit=100