### PR TITLE
fix(visibility): update HST constraints for reduced gyro mode

### DIFF
--- a/migrations/versions/_2026_08_10_1815-dd08ad0df8af_fix_hst_sun_angle_constraint.py
+++ b/migrations/versions/_2026_08_10_1815-dd08ad0df8af_fix_hst_sun_angle_constraint.py
@@ -1,0 +1,91 @@
+"""fix HST sun angle constraint
+
+Revision ID: dd08ad0df8af
+Revises: cb5340af20da
+Create Date: 2026-08-10 18:15:14.809021
+
+"""
+
+import uuid
+from typing import Sequence, Union
+
+from across.tools.visibility.constraints import SunAngleConstraint
+from alembic import op
+from sqlalchemy import orm
+
+import migrations.versions.model_snapshots.models_2026_05_26 as models
+
+# revision identifiers, used by Alembic.
+revision: str = "dd08ad0df8af"
+down_revision: Union[str, None] = "cb5340af20da"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# The minimum sun angle for HST in single gyro mode is 62.5 degrees, as per the HST documentation:
+# https://www.stsci.edu/files/live/sites/www/files/home/hst/observing/_documents/HST-RGM-Primer.pdf
+HST_SINGLE_GYRO_MODE_MIN_SUN_ANGLE = 62.5
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    session = orm.Session(bind=bind, expire_on_commit=False)
+
+    hst_sun_angle_constraint = models.Constraint(
+        id=uuid.UUID("ee3758c5-2a58-4c90-bf1d-1dac33daff63"),
+        constraint_type="Sun Angle",
+        constraint_parameters=SunAngleConstraint(
+            min_angle=HST_SINGLE_GYRO_MODE_MIN_SUN_ANGLE,
+        ).model_dump(),
+    )
+    session.add(hst_sun_angle_constraint)
+    session.flush()
+
+    hst_telescope = (
+        session.query(models.Telescope)
+        .where(models.Telescope.short_name == "HST")
+        .one()
+    )
+
+    for instrument in hst_telescope.instruments:
+        for constraint in instrument.constraints:
+            if constraint.constraint_type == "Sun Angle":
+                instrument.constraints.remove(constraint)
+
+        instrument.constraints.append(hst_sun_angle_constraint)
+        session.add(instrument)
+
+    session.commit()
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    session = orm.Session(bind=bind, expire_on_commit=False)
+
+    hst_sun_angle_constraint = (
+        session.query(models.Constraint)
+        .where(models.Constraint.id == "ee3758c5-2a58-4c90-bf1d-1dac33daff63")
+        .one()
+    )
+
+    old_sun_angle_constraint = (
+        session.query(models.Constraint)
+        .where(models.Constraint.id == "d530a37d-0fc1-4ea3-8bae-1ab4940308b5")
+        .one()
+    )
+
+    hst_telescope = (
+        session.query(models.Telescope)
+        .where(models.Telescope.short_name == "HST")
+        .one()
+    )
+
+    for instrument in hst_telescope.instruments:
+        for constraint in instrument.constraints:
+            if constraint.id == hst_sun_angle_constraint.id:
+                instrument.constraints.remove(constraint)
+
+        instrument.constraints.append(old_sun_angle_constraint)
+        session.add(instrument)
+
+    session.delete(hst_sun_angle_constraint)
+    session.commit()

--- a/migrations/versions/_2026_08_10_1815-dd08ad0df8af_fix_hst_sun_angle_constraint.py
+++ b/migrations/versions/_2026_08_10_1815-dd08ad0df8af_fix_hst_sun_angle_constraint.py
@@ -9,6 +9,7 @@ Create Date: 2026-08-10 18:15:14.809021
 import uuid
 from typing import Sequence, Union
 
+from across.tools.core.enums import ConstraintType
 from across.tools.visibility.constraints import SunAngleConstraint
 from alembic import op
 from sqlalchemy import orm
@@ -32,7 +33,7 @@ def upgrade() -> None:
 
     hst_sun_angle_constraint = models.Constraint(
         id=uuid.UUID("ee3758c5-2a58-4c90-bf1d-1dac33daff63"),
-        constraint_type="Sun Angle",
+        constraint_type=ConstraintType.SUN,
         constraint_parameters=SunAngleConstraint(
             min_angle=HST_SINGLE_GYRO_MODE_MIN_SUN_ANGLE,
         ).model_dump(),
@@ -48,7 +49,7 @@ def upgrade() -> None:
 
     for instrument in hst_telescope.instruments:
         for constraint in instrument.constraints:
-            if constraint.constraint_type == "Sun Angle":
+            if constraint.constraint_type == ConstraintType.SUN.value:
                 instrument.constraints.remove(constraint)
 
         instrument.constraints.append(hst_sun_angle_constraint)

--- a/migrations/versions/_2026_08_10_1815-dd08ad0df8af_fix_hst_sun_angle_constraint.py
+++ b/migrations/versions/_2026_08_10_1815-dd08ad0df8af_fix_hst_sun_angle_constraint.py
@@ -1,7 +1,7 @@
 """fix HST sun angle constraint
 
 Revision ID: dd08ad0df8af
-Revises: cb5340af20da
+Revises: 5e170132081b
 Create Date: 2026-08-10 18:15:14.809021
 
 """
@@ -18,7 +18,7 @@ import migrations.versions.model_snapshots.models_2026_05_26 as models
 
 # revision identifiers, used by Alembic.
 revision: str = "dd08ad0df8af"
-down_revision: Union[str, None] = "cb5340af20da"
+down_revision: Union[str, None] = "5e170132081b"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/migrations/versions/_2026_08_13_1815-dd08ad0df8af_fix_hst_sun_angle_constraint.py
+++ b/migrations/versions/_2026_08_13_1815-dd08ad0df8af_fix_hst_sun_angle_constraint.py
@@ -1,7 +1,7 @@
 """fix HST sun angle constraint
 
 Revision ID: dd08ad0df8af
-Revises: 5e170132081b
+Revises: 5a093993a1a3
 Create Date: 2026-08-10 18:15:14.809021
 
 """
@@ -18,7 +18,7 @@ import migrations.versions.model_snapshots.models_2026_05_26 as models
 
 # revision identifiers, used by Alembic.
 revision: str = "dd08ad0df8af"
-down_revision: Union[str, None] = "5e170132081b"
+down_revision: Union[str, None] = "5a093993a1a3"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Description

This PR updates HST instruments' `SunAngleConstraint` values to be consistent with the values used by HST in its reduced gyro mode. HST has been operating in reduced gyro mode for some time. These updated values should bring ACROSS's visibility calculations more in line with the calculations provided by external tools such as the APT. Note that there may be more constraints that need to be added for reduced gyro mode -- I'm in the process of reaching out to folks at STScI to determine if/how we can represent them in our system.

### Resolved Issue(s)

Resolves #722 

## Acceptance Criteria

1. Migrations should upgrade and downgrade
2. Visibility calculations with HST should still work 

## Testing

1. Pull this branch and run `make reset` to run the new migrations
2. Perform a GET for an HST instrument and verify the following is part of the returned `constraints` payload:
```
      {
        "short_name": "Sun",
        "name": "Sun Angle",
        "min_angle": 62.5,
        "max_angle": null
      }
```
3. Run `alembic downgrade -1` and check that the older `SunAngleConstraint` values are restored